### PR TITLE
Improved error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ itself.
       * [Multiple Return Values](#multiple-return-values)
       * [Interpolation](#interpolation)
       * [Stateful Functions (Objects)](#stateful-functions-objects)
+      * [Errors](#errors)
 
 
 <!--te-->
@@ -727,4 +728,113 @@ func main() {
 $ ok run objects
 42
 {"Age": 42, "Name": "John"}
+```
+
+Errors
+------
+
+```
+// Errors in ok work very similar to exceptions in some other languages. If you
+// are not familar with exceptions, read on.
+
+// Any function can raise an error. Raising an error prevents any more code from
+// running, the code will jump to an error handler. If there is no error handler
+// in this function it will be raised to the caller, and so on until it's
+// handled, as we will see.
+func f1(arg number) number {
+    if arg == 42 {
+        // Error is a build in type that takes a message. Since we do not handle
+        // the error here, it will be passed up to the caller.
+        raise Error("can't work with 42")
+    }
+
+    return arg + 3
+}
+
+// Sometimes just a message is not enough. We can create our own custom error
+// type by implementing the Error interface. That is, any type that has the
+// property Error of type string.
+func argError(arg number, prob string) argError {
+    // Save these properties for later.
+    Arg = arg
+    Prob = prob
+
+    // This satisfies the Error interface.
+    Error = "{arg} - {prob}"
+}
+
+// f2 performs the same logic as f1, but we raise our custom error instead.
+func f2(arg number) number {
+    if arg == 42 {
+        // Our custom error will act like an Error, but we can also inspect it.
+        raise argError(arg, "can't work with it")
+    }
+
+    return arg + 3
+}
+
+func main() {
+    for _, i in [7, 42] {
+        try {
+            r = f1(i)
+
+            // If f1 raised an error this will not run because the code will
+            // jump immediately to the error handler below.
+            print("f1 worked:", r)
+        } on Error {
+            // When an error is caught, a special "err" variable is provided.
+            // Since the Error type must include an Error string property, we
+            // can print it out now.
+            print("f1 failed:", err.Error)
+        }
+    }
+
+    // Let's try the same thing with f2, which has the same logic, but raises a
+    // custom error type.
+    for _, i in [7, 42] {
+        try {
+            r = f2(i)
+            print("f2 worked:", r)
+        } on Error {
+            // The type of "err" is still an Error, so we cannot access Arg and
+            // Prob. We can rely on the Error message through.
+            print("f2 failed:", err.Error)
+        }
+    }
+
+    try {
+        f2(42)
+    } on argError {
+        // The "err" is now a type of argError, so we can inpect those extra
+        // properties. Be careful, if the error raised was not of type argError,
+        // then it will not be handled here. Instead it would be passed up to
+        // the caller to handle.
+        print(err.Arg)
+        print(err.Prob)
+    }
+
+    // You can have multiple handlers. Only the first match will be executed.
+    // This let's you provide more generic handlers if specific cases are not
+    // raised.
+    try {
+        f1(42)
+    } on argError {
+        // f1 raises an Error, so it will not be caught here.
+        print("This should not happen!")
+    } on Error {
+        // This will handle the error.
+        print("f1 failed, all we have is the message:", err.Error)
+    }
+}
+```
+
+```
+$ ok run errors
+f1 worked: 10
+f1 failed: can't work with 42
+f2 worked: 10
+f2 failed: 42 - can't work with it
+42
+can't work with it
+f1 failed, all we have is the message: can't work with 42
 ```

--- a/cmd/lib-gen/main.go
+++ b/cmd/lib-gen/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"os"
 
@@ -20,28 +21,56 @@ func check(err error) {
 }
 
 func main() {
-	pkg, errs := compiler.CompilePackage("lib/math", false)
-	util.CheckErrorsWithExit(errs)
+	packages, err := ioutil.ReadDir("lib")
+	check(err)
+
+	packageNames := map[string]bool{}
+
+	funcs := map[string]*vm.InternalDefinition{}
+	for _, pathInfo := range packages {
+		if !pathInfo.IsDir() {
+			continue
+		}
+
+		pkgName := pathInfo.Name()
+
+		// lang is not importable. It's basic language features and tests.
+		if pkgName != "lang" {
+			packageNames[pkgName] = true
+		}
+
+		pkg, errs := compiler.CompilePackage("lib/"+pkgName, false)
+		util.CheckErrorsWithExit(errs)
+
+		for name, fn := range pkg.Funcs {
+			// TODO(elliot): Filter out unexported entities.
+
+			funcDef := pkg.FuncDefs[name]
+
+			// We don't need to serialize this.
+			funcDef.Statements = nil
+
+			key := pkgName + "." + name
+			if pkgName == "lang" {
+				key = name
+			}
+
+			funcs[key] = &vm.InternalDefinition{
+				CompiledFunc: fn,
+				FuncDef:      funcDef,
+			}
+		}
+	}
 
 	f, err := os.Create("vm/lib.go")
 	check(err)
 
-	funcs := map[string]*vm.InternalDefinition{}
-	for name, fn := range pkg.Funcs {
-		funcDef := pkg.FuncDefs[name]
-
-		// We don't need to serialize this.
-		funcDef.Statements = nil
-
-		funcs["math."+name] = &vm.InternalDefinition{
-			CompiledFunc: fn,
-			FuncDef:      funcDef,
-		}
-	}
-
 	fmt.Fprintf(f, "package vm\n\n")
 	fmt.Fprintf(f, "import \"github.com/elliotchance/ok/ast\"\n\n")
 	fmt.Fprintf(f, "func init() {\n")
+	fmt.Fprintf(f, "\tPackages = ")
+	util.Render(f, packageNames, "\t", true)
+	fmt.Fprintf(f, "\n")
 	fmt.Fprintf(f, "\tLib = ")
 	util.Render(f, funcs, "\t", true)
 	fmt.Fprintf(f, "\n}\n")

--- a/compiler/error_scope.go
+++ b/compiler/error_scope.go
@@ -28,6 +28,10 @@ func compileErrorScope(compiledFunc *vm.CompiledFunc, n *ast.ErrorScope, fns map
 			Type: on.Type,
 		})
 
+		// Provide the err variable. The runtime value will be provided by the
+		// On instruction above.
+		compiledFunc.NewVariable("err", on.Type)
+
 		err := compileBlock(compiledFunc, on.Statements, nil, nil, fns)
 		if err != nil {
 			return err

--- a/compiler/package.go
+++ b/compiler/package.go
@@ -8,6 +8,7 @@ import (
 	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/parser"
 	"github.com/elliotchance/ok/util"
+	"github.com/elliotchance/ok/vm"
 )
 
 func CompilePackage(dir string, includeTests bool) (*Compiled, []error) {
@@ -51,9 +52,7 @@ func CompilePackage(dir string, includeTests bool) (*Compiled, []error) {
 
 			// Ignore builtin libraries as they are already provided to the VM
 			// through vm/lib.go. See Makefile.
-			//
-			// TODO(elliot): This needs to be smarter.
-			if pkg == "math" {
+			if vm.Packages[pkg] {
 				continue
 			}
 

--- a/lib/lang/README.md
+++ b/lib/lang/README.md
@@ -1,3 +1,12 @@
 # lang
 
+- [Error](#Error)
+
+## Error
+
+```
+func Error(message string) Error
+```
+
+Error is a basic type to carry an error message.
 

--- a/lib/lang/error.ok
+++ b/lib/lang/error.ok
@@ -1,0 +1,4 @@
+// Error is a basic type to carry an error message.
+func Error(message string) Error {
+    Error = message
+}

--- a/tests/example-errors/main.ok
+++ b/tests/example-errors/main.ok
@@ -1,0 +1,92 @@
+// Errors in ok work very similar to exceptions in some other languages. If you
+// are not familar with exceptions, read on.
+
+// Any function can raise an error. Raising an error prevents any more code from
+// running, the code will jump to an error handler. If there is no error handler
+// in this function it will be raised to the caller, and so on until it's
+// handled, as we will see.
+func f1(arg number) number {
+    if arg == 42 {
+        // Error is a build in type that takes a message. Since we do not handle
+        // the error here, it will be passed up to the caller.
+        raise Error("can't work with 42")
+    }
+
+    return arg + 3
+}
+
+// Sometimes just a message is not enough. We can create our own custom error
+// type by implementing the Error interface. That is, any type that has the
+// property Error of type string.
+func argError(arg number, prob string) argError {
+    // Save these properties for later.
+    Arg = arg
+    Prob = prob
+
+    // This satisfies the Error interface.
+    Error = "{arg} - {prob}"
+}
+
+// f2 performs the same logic as f1, but we raise our custom error instead.
+func f2(arg number) number {
+    if arg == 42 {
+        // Our custom error will act like an Error, but we can also inspect it.
+        raise argError(arg, "can't work with it")
+    }
+
+    return arg + 3
+}
+
+func main() {
+    for _, i in [7, 42] {
+        try {
+            r = f1(i)
+
+            // If f1 raised an error this will not run because the code will
+            // jump immediately to the error handler below.
+            print("f1 worked:", r)
+        } on Error {
+            // When an error is caught, a special "err" variable is provided.
+            // Since the Error type must include an Error string property, we
+            // can print it out now.
+            print("f1 failed:", err.Error)
+        }
+    }
+
+    // Let's try the same thing with f2, which has the same logic, but raises a
+    // custom error type.
+    for _, i in [7, 42] {
+        try {
+            r = f2(i)
+            print("f2 worked:", r)
+        } on Error {
+            // The type of "err" is still an Error, so we cannot access Arg and
+            // Prob. We can rely on the Error message through.
+            print("f2 failed:", err.Error)
+        }
+    }
+
+    try {
+        f2(42)
+    } on argError {
+        // The "err" is now a type of argError, so we can inpect those extra
+        // properties. Be careful, if the error raised was not of type argError,
+        // then it will not be handled here. Instead it would be passed up to
+        // the caller to handle.
+        print(err.Arg)
+        print(err.Prob)
+    }
+
+    // You can have multiple handlers. Only the first match will be executed.
+    // This let's you provide more generic handlers if specific cases are not
+    // raised.
+    try {
+        f1(42)
+    } on argError {
+        // f1 raises an Error, so it will not be caught here.
+        print("This should not happen!")
+    } on Error {
+        // This will handle the error.
+        print("f1 failed, all we have is the message:", err.Error)
+    }
+}

--- a/tests/example-errors/stdout.txt
+++ b/tests/example-errors/stdout.txt
@@ -1,0 +1,7 @@
+f1 worked: 10
+f1 failed: can't work with 42
+f2 worked: 10
+f2 failed: 42 - can't work with it
+42
+can't work with it
+f1 failed, all we have is the message: can't work with 42

--- a/tests/strings/main.ok
+++ b/tests/strings/main.ok
@@ -1,0 +1,5 @@
+import "strings"
+
+func main() {
+    print(strings.Repeat("foo", 3))
+}

--- a/tests/strings/stdout.txt
+++ b/tests/strings/stdout.txt
@@ -1,0 +1,1 @@
+foofoofoo

--- a/vm/raise.go
+++ b/vm/raise.go
@@ -15,7 +15,8 @@ type Raise struct {
 
 // Execute implements the Instruction interface for the VM.
 func (ins *Raise) Execute(registers map[string]*ast.Literal, _ *int, vm *VM) error {
-	vm.Err = ins.Type
+	vm.ErrType = ins.Type
+	vm.ErrValue = registers[ins.Err]
 
 	return nil
 }


### PR DESCRIPTION
There is now a built in Error type and I have provided an example of
using this can custom error types in the README.

When errors are handled you can now use a special "err" variable to
inspect them.

Also found an unrelated bug where the strings package was not being
included in the final ok binary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/ok/47)
<!-- Reviewable:end -->
