### PR TITLE
Added "finally"

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ itself.
       * [Interpolation](#interpolation)
       * [Stateful Functions (Objects)](#stateful-functions-objects)
       * [Errors](#errors)
+      * [Finally](#finally)
 
 
 <!--te-->
@@ -837,4 +838,63 @@ f2 failed: 42 - can't work with it
 42
 can't work with it
 f1 failed, all we have is the message: can't work with 42
+```
+
+Finally
+-------
+
+```
+func f1(arg number) number {
+    if arg == 42 {
+        raise Error("can't work with 42")
+    }
+
+    return arg + 3
+}
+
+func main() {
+    for i in [7, 42] {
+        try {
+            r = f1(i)
+            print("f1 worked:", r)
+        } on Error {
+            print("f1 failed:", err.Error)
+        } finally {
+            // Finally will always run after the try block or the error
+            // handler.
+            print("finally f1")
+        }
+    }
+
+    for i in [7, 42] {
+        try {
+            r = f2(i)
+            print("f2 worked:", r)
+        } on Error {
+            print("f2 failed:", err.Error)
+        }
+    }
+}
+
+func f2(arg number) number {
+    try {
+        return f1(arg)
+    } finally {
+        // Finally will always run before the return, even if there is
+        // an error.
+        print("f2 done")
+    }
+}
+```
+
+```
+$ ok run finally
+f1 worked: 10
+finally f1
+f1 failed: can't work with 42
+finally f1
+f2 done
+f2 worked: 10
+f2 done
+f2 failed: can't work with 42
 ```

--- a/ast/asttest/assert.go
+++ b/ast/asttest/assert.go
@@ -23,6 +23,7 @@ func cmpOptions() cmp.Options {
 		cmpopts.IgnoreFields(ast.Comment{}, "Pos"),
 		cmpopts.IgnoreFields(ast.Continue{}, "Pos"),
 		cmpopts.IgnoreFields(ast.ErrorScope{}, "Pos"),
+		cmpopts.IgnoreFields(ast.Finally{}, "Pos"),
 		cmpopts.IgnoreFields(ast.For{}, "Pos"),
 		cmpopts.IgnoreFields(ast.Func{}, "Pos"),
 		cmpopts.IgnoreFields(ast.Group{}, "Pos"),

--- a/ast/error_scope.go
+++ b/ast/error_scope.go
@@ -16,13 +16,36 @@ func (node *On) Position() string {
 	return node.Pos
 }
 
+// Finally will always be called on success or failure.
+type Finally struct {
+	// Index is the unique counter for each finally block in this function. It
+	// is used to activate and deactivate finally blocks by the VM at runtime.
+	Index int
+
+	// Statement may be nil.
+	Statements []Node
+
+	Pos string
+}
+
+// Position returns the position.
+func (node *Finally) Position() string {
+	return node.Pos
+}
+
 // ErrorScope represents the try/on error scope.
 type ErrorScope struct {
 	// Statements is what will be run in this scope. It is allowed to be nil.
 	Statements []Node
 
-	On  []*On
+	// On can have zero or more elements.
+	On []*On
+
 	Pos string
+
+	// Finally is optional. An empty finally block and no finally block are
+	// treated the same way.
+	Finally *Finally
 }
 
 // Position returns the position.

--- a/lexer/token.go
+++ b/lexer/token.go
@@ -28,6 +28,7 @@ const (
 	TokenContinue = "continue"
 	TokenData     = "data"
 	TokenElse     = "else"
+	TokenFinally  = "finally"
 	TokenFor      = "for"
 	TokenFunc     = "func"
 	TokenIf       = "if"

--- a/lexer/tokenize.go
+++ b/lexer/tokenize.go
@@ -342,7 +342,7 @@ func tokenWord(word string, pos Pos) Token {
 		"func", "return", "import",
 
 		// Errors
-		"try", "raise", "on":
+		"try", "raise", "on", "finally":
 		return NewToken(word, word, pos.add(-len(word)))
 	}
 

--- a/lexer/tokenize_test.go
+++ b/lexer/tokenize_test.go
@@ -1129,6 +1129,13 @@ func TestTokenizeString(t *testing.T) {
 				{lexer.TokenEOF, "", false, pos(3)},
 			},
 		},
+		"finally": {
+			str: `finally`,
+			expected: []lexer.Token{
+				{lexer.TokenFinally, "finally", false, pos(1)},
+				{lexer.TokenEOF, "", false, pos(8)},
+			},
+		},
 	} {
 		t.Run(testName, func(t *testing.T) {
 			options := lexer.Options{

--- a/parser/error_scope_test.go
+++ b/parser/error_scope_test.go
@@ -68,6 +68,52 @@ func TestErrorScope(t *testing.T) {
 				},
 			},
 		},
+		"try-on-finally": {
+			str: "try { print() } on SomethingElse { foo() } finally { bar() }",
+			expected: &ast.ErrorScope{
+				Statements: []ast.Node{
+					&ast.Call{
+						FunctionName: "print",
+					},
+				},
+				On: []*ast.On{
+					{
+						Type: "SomethingElse",
+						Statements: []ast.Node{
+							&ast.Call{
+								FunctionName: "foo",
+							},
+						},
+					},
+				},
+				Finally: &ast.Finally{
+					Index: 0,
+					Statements: []ast.Node{
+						&ast.Call{
+							FunctionName: "bar",
+						},
+					},
+				},
+			},
+		},
+		"try-finally": {
+			str: "try { print() } finally { foo() }",
+			expected: &ast.ErrorScope{
+				Statements: []ast.Node{
+					&ast.Call{
+						FunctionName: "print",
+					},
+				},
+				Finally: &ast.Finally{
+					Index: 0,
+					Statements: []ast.Node{
+						&ast.Call{
+							FunctionName: "foo",
+						},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(testName, func(t *testing.T) {
 			str := fmt.Sprintf("func main() { %s }", test.str)

--- a/parser/func.go
+++ b/parser/func.go
@@ -41,6 +41,11 @@ func consumeFunc(parser *Parser, offset int) (_ *ast.Func, _ int, finalErr error
 		}
 	}
 
+	parser.functionNames = append(parser.functionNames, fn.Name)
+	defer func() {
+		parser.functionNames = parser.functionNames[:len(parser.functionNames)-1]
+	}()
+
 	fn.Statements, offset, err = consumeBlock(parser, offset)
 	if err != nil {
 		return nil, originalOffset, err

--- a/parser/func_test.go
+++ b/parser/func_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/parser"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -104,6 +103,99 @@ func TestFunc(t *testing.T) {
 			expected: map[string]*ast.Func{
 				"Abs": {
 					Name: "Abs",
+				},
+			},
+		},
+		"try-finally-2": {
+			str: "func main() {" +
+				"try { print() } finally { foo() } " +
+				"try { print() } finally { bar() }" +
+				"}",
+			expected: map[string]*ast.Func{
+				"main": {
+					Name: "main",
+					Statements: []ast.Node{
+						&ast.ErrorScope{
+							Statements: []ast.Node{
+								&ast.Call{
+									FunctionName: "print",
+								},
+							},
+							Finally: &ast.Finally{
+								Index: 0,
+								Statements: []ast.Node{
+									&ast.Call{
+										FunctionName: "foo",
+									},
+								},
+							},
+						},
+						&ast.ErrorScope{
+							Statements: []ast.Node{
+								&ast.Call{
+									FunctionName: "print",
+								},
+							},
+							Finally: &ast.Finally{
+								Index: 1,
+								Statements: []ast.Node{
+									&ast.Call{
+										FunctionName: "bar",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"try-finally-3": {
+			str: "func main() {" +
+				"try { print() } finally { foo() } " +
+				"}" +
+				"func main2() {" +
+				"try { print() } finally { bar() }" +
+				"}",
+			expected: map[string]*ast.Func{
+				"main": {
+					Name: "main",
+					Statements: []ast.Node{
+						&ast.ErrorScope{
+							Statements: []ast.Node{
+								&ast.Call{
+									FunctionName: "print",
+								},
+							},
+							Finally: &ast.Finally{
+								Index: 0,
+								Statements: []ast.Node{
+									&ast.Call{
+										FunctionName: "foo",
+									},
+								},
+							},
+						},
+					},
+				},
+				"main2": {
+					Name: "main2",
+					Statements: []ast.Node{
+						&ast.ErrorScope{
+							Statements: []ast.Node{
+								&ast.Call{
+									FunctionName: "print",
+								},
+							},
+							Finally: &ast.Finally{
+								Index: 0,
+								Statements: []ast.Node{
+									&ast.Call{
+										FunctionName: "bar",
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -8,7 +8,8 @@ import (
 // ParseString parses source code and returns the AST for the file.
 func ParseString(s string, fileName string) *Parser {
 	parser := &Parser{
-		File: &File{},
+		File:       &File{},
+		finalizers: map[string][]*ast.Finally{},
 	}
 	parser.File.Funcs = map[string]*ast.Func{}
 	parser.File.Imports = map[string]string{}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -9,8 +9,10 @@ import (
 )
 
 type Parser struct {
-	errors []error
-	File   *File
+	errors        []error
+	File          *File
+	finalizers    map[string][]*ast.Finally
+	functionNames []string
 }
 
 // AppendError adds an error to the stack.
@@ -41,4 +43,12 @@ func (p *Parser) AppendErrorf(node ast.Node, format string, args ...interface{})
 // Errors returns all errors.
 func (p *Parser) Errors() []error {
 	return p.errors
+}
+
+// AppendFinally will track finalizers until the function is finished, then it
+// will be reset.
+func (p *Parser) AppendFinally(finally *ast.Finally) {
+	funcName := p.functionNames[len(p.functionNames)-1]
+	finally.Index = len(p.finalizers[funcName])
+	p.finalizers[funcName] = append(p.finalizers[funcName], finally)
 }

--- a/tests/example-finally/main.ok
+++ b/tests/example-finally/main.ok
@@ -1,0 +1,41 @@
+func f1(arg number) number {
+    if arg == 42 {
+        raise Error("can't work with 42")
+    }
+
+    return arg + 3
+}
+
+func main() {
+    for i in [7, 42] {
+        try {
+            r = f1(i)
+            print("f1 worked:", r)
+        } on Error {
+            print("f1 failed:", err.Error)
+        } finally {
+            // Finally will always run after the try block or the error
+            // handler.
+            print("finally f1")
+        }
+    }
+
+    for i in [7, 42] {
+        try {
+            r = f2(i)
+            print("f2 worked:", r)
+        } on Error {
+            print("f2 failed:", err.Error)
+        }
+    }
+}
+
+func f2(arg number) number {
+    try {
+        return f1(arg)
+    } finally {
+        // Finally will always run before the return, even if there is
+        // an error.
+        print("f2 done")
+    }
+}

--- a/tests/example-finally/stdout.txt
+++ b/tests/example-finally/stdout.txt
@@ -1,0 +1,8 @@
+f1 worked: 10
+finally f1
+f1 failed: can't work with 42
+finally f1
+f2 done
+f2 worked: 10
+f2 done
+f2 failed: can't work with 42

--- a/vm/call.go
+++ b/vm/call.go
@@ -12,7 +12,7 @@ type Call struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Call) Execute(registers map[string]*ast.Literal, _ *int, vm *VM) error {
+func (ins *Call) Execute(registers map[string]*ast.Literal, i *int, vm *VM) error {
 	results, err := vm.call(ins.FunctionName, ins.Arguments)
 	if err != nil {
 		return err
@@ -23,6 +23,12 @@ func (ins *Call) Execute(registers map[string]*ast.Literal, _ *int, vm *VM) erro
 	}
 
 	vm.stack = vm.stack[:len(vm.stack)-1]
+
+	// We cannot rollback the FinallyBlocks stack here because we may need to
+	// run some of them as part of the return. They will be removed in the
+	// parent caller when it's finished with them
+
 	vm.Return = nil
+
 	return nil
 }

--- a/vm/finally.go
+++ b/vm/finally.go
@@ -1,0 +1,18 @@
+package vm
+
+import (
+	"github.com/elliotchance/ok/ast"
+)
+
+// Finally will activate or deactivate a finally block.
+type Finally struct {
+	Index int
+	Run   bool
+}
+
+// Execute implements the Instruction interface for the VM.
+func (ins *Finally) Execute(registers map[string]*ast.Literal, _ *int, vm *VM) error {
+	vm.FinallyBlocks[len(vm.FinallyBlocks)-1][ins.Index].Run = ins.Run
+
+	return nil
+}

--- a/vm/func.go
+++ b/vm/func.go
@@ -8,6 +8,12 @@ type CompiledFunc struct {
 	Registers      int
 	Variables      map[string]string
 	ObjectRegister string
+	Finally        [][]Instruction
+}
+
+type FinallyBlock struct {
+	Run          bool
+	Instructions []Instruction
 }
 
 func (c *CompiledFunc) NextRegister() string {

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -33,4 +33,26 @@ func add(a, b number) number {
 		m := vm.NewVM(f.Funcs, f.Tests, "pkg")
 		assert.NoError(t, m.Run())
 	})
+
+	t.Run("finally-is-called-before-return", func(t *testing.T) {
+		p := parser.ParseString(`
+func f2(arg number) number {
+    try {
+        return arg + 10
+    } finally {
+        print("f2 done")
+    }
+}
+
+func main() {
+    print(f2(123))
+}
+`, "a.ok")
+		require.Nil(t, p.Errors())
+		f, err := compiler.CompileFile(p.File)
+		require.NoError(t, err)
+
+		m := vm.NewVM(f.Funcs, f.Tests, "pkg")
+		assert.NoError(t, m.Run())
+	})
 }


### PR DESCRIPTION
Finally is an optional single block that can be added after any
(including zero) error handlers to guarantee that the code is executed,
even if an error occurs or a premature return happens:

    try {
        r = f1(i)
        print("f1 worked:", r)
    } on Error {
        print("f1 failed:", err.Error)
    } finally {
        print("finally f1")
    }

Or:

    try {
        return f1(arg)
    } finally {
        print("f2 done")
    }

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/ok/49)
<!-- Reviewable:end -->
