### PR TITLE
Added "ok asm"

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ itself.
    * [IDE Support](#ide-support)
       * [Visual Studio Code](#visual-studio-code)
    * [Command Line Interface](#command-line-interface)
+      * [asm](#asm)
       * [build](#build)
       * [doc](#doc)
       * [run](#run)
@@ -167,6 +168,32 @@ extension inside of VSCode.
 
 Command Line Interface
 ======================
+
+asm
+---
+
+The `asm` tool is useful for debugging. It will print out human-readable
+descriptions of each of the compiled instructions for one or more
+functions. Usage:
+
+```bash
+ok asm package-name function1 function2 ...
+```
+
+Without providing any arguments it will use the current package and
+output the `main` function, this is equivalent to running:
+
+```bash
+ok asm . main
+```
+
+Here is the output from the `hello-world` example:
+
+```
+func main():
+    1 Assign                 # $1 = "Hello, World!"
+    2 Print                  # print($1)
+```
 
 build
 -----

--- a/ast/literal.go
+++ b/ast/literal.go
@@ -1,5 +1,9 @@
 package ast
 
+import (
+	"encoding/json"
+)
+
 // Literal represents a literal of any type.
 type Literal struct {
 	Kind  string
@@ -17,4 +21,18 @@ type Literal struct {
 // Position returns the position.
 func (node *Literal) Position() string {
 	return node.Pos
+}
+
+// String is the human-readable representation of the value. To make it easier
+// we just output everything as JSON.
+func (node *Literal) String() string {
+	// Ignore error, it shouldn't happen, and if it does there is nothing
+	// sensible we can do in that case.
+	v, _ := json.Marshal(node.Value)
+
+	// TODO(elliot): This doesn't handle non-scalar types. However, they can
+	//  only exist at runtime so for what this function is used for it may not
+	//  be an issue.
+
+	return string(v)
 }

--- a/cmd/asm/main.go
+++ b/cmd/asm/main.go
@@ -1,0 +1,45 @@
+package asm
+
+import (
+	"fmt"
+
+	"github.com/elliotchance/ok/compiler"
+	"github.com/elliotchance/ok/util"
+)
+
+type Command struct{}
+
+// Description is shown in "ok -help".
+func (*Command) Description() string {
+	return "show compiled instructions"
+}
+
+// Run is the entry point for the "ok asm" command.
+func (*Command) Run(args []string) {
+	if len(args) < 1 {
+		args = []string{"."}
+	}
+	if len(args) < 2 {
+		args = append(args, "main")
+	}
+
+	pkg, errs := compiler.CompilePackage(args[0], false)
+	util.CheckErrorsWithExit(errs)
+
+	for _, fnName := range args[1:] {
+		fn, exists := pkg.FuncDefs[fnName]
+		if !exists {
+			// TODO(elliot): This could be handled more gracefully.
+			panic("no such function: " + fnName)
+		}
+
+		fmt.Println(fn.String() + ":")
+
+		for i, ins := range pkg.Funcs[fn.Name].Instructions {
+			ty := fmt.Sprintf("%T", ins)[4:]
+
+			// "-22" is chosen here because is is the longer instruction name.
+			fmt.Printf("  %3d %-22s # %s\n", i+1, ty, ins)
+		}
+	}
+}

--- a/compiler/array.go
+++ b/compiler/array.go
@@ -8,7 +8,7 @@ import (
 	"github.com/elliotchance/ok/vm"
 )
 
-func compileArray(compiledFunc *vm.CompiledFunc, n *ast.Array, fns map[string]*ast.Func) (string, string, error) {
+func compileArray(compiledFunc *vm.CompiledFunc, n *ast.Array, fns map[string]*ast.Func) (vm.Register, string, error) {
 	if len(n.Elements) == 0 && n.Kind == "" {
 		err := fmt.Errorf("%s empty array needs to specify a type",
 			n.Position())

--- a/compiler/assert.go
+++ b/compiler/assert.go
@@ -7,7 +7,11 @@ import (
 	"github.com/elliotchance/ok/vm"
 )
 
-func compileAssert(compiledFunc *vm.CompiledFunc, n *ast.Assert, fns map[string]*ast.Func) error {
+func compileAssert(
+	compiledFunc *vm.CompiledFunc,
+	n *ast.Assert,
+	fns map[string]*ast.Func,
+) error {
 	left, right, returns, returnKind, err := compileComparison(compiledFunc, n.Expr, fns)
 	if err != nil {
 		return err

--- a/compiler/assign.go
+++ b/compiler/assign.go
@@ -10,7 +10,8 @@ import (
 )
 
 type resultKindPair struct {
-	result, kind string
+	result vm.Register
+	kind   string
 }
 
 func compileAssign(compiledFunc *vm.CompiledFunc, node *ast.Assign, fns map[string]*ast.Func) error {
@@ -64,7 +65,7 @@ func compileAssign(compiledFunc *vm.CompiledFunc, node *ast.Assign, fns map[stri
 				})
 			} else {
 				ins := &vm.Assign{
-					VariableName: variableName,
+					VariableName: vm.Register(variableName),
 					Register:     rr.result,
 				}
 				compiledFunc.Append(ins)

--- a/compiler/call.go
+++ b/compiler/call.go
@@ -7,7 +7,7 @@ import (
 	"github.com/elliotchance/ok/vm"
 )
 
-type builtinFn func(compiledFunc *vm.CompiledFunc, args []string) (vm.Instruction, string, string, error)
+type builtinFn func(compiledFunc *vm.CompiledFunc, args []vm.Register) (vm.Instruction, vm.Register, string, error)
 
 // TODO(elliot): These needs to check function signatures.
 var builtinFunctions = map[string]builtinFn{
@@ -20,8 +20,12 @@ var builtinFunctions = map[string]builtinFn{
 	"char":   funcChar,
 }
 
-func compileCall(compiledFunc *vm.CompiledFunc, call *ast.Call, fns map[string]*ast.Func) ([]string, []string, error) {
-	var argResults []string
+func compileCall(
+	compiledFunc *vm.CompiledFunc,
+	call *ast.Call,
+	fns map[string]*ast.Func,
+) ([]vm.Register, []string, error) {
+	var argResults []vm.Register
 	for _, arg := range call.Arguments {
 		argResult, _, err := compileExpr(compiledFunc, arg, fns)
 		if err != nil {
@@ -39,7 +43,7 @@ func compileCall(compiledFunc *vm.CompiledFunc, call *ast.Call, fns map[string]*
 
 		compiledFunc.Append(ins)
 
-		return []string{result}, []string{returnType}, nil
+		return []vm.Register{result}, []string{returnType}, nil
 	}
 
 	toCall := fns[call.FunctionName]
@@ -58,7 +62,7 @@ func compileCall(compiledFunc *vm.CompiledFunc, call *ast.Call, fns map[string]*
 	}
 
 	// Prepare enough return registers.
-	var returnRegisters []string
+	var returnRegisters []vm.Register
 	for range toCall.Returns {
 		returnRegisters = append(returnRegisters, compiledFunc.NextRegister())
 	}
@@ -74,7 +78,7 @@ func compileCall(compiledFunc *vm.CompiledFunc, call *ast.Call, fns map[string]*
 	return returnRegisters, toCall.Returns, nil
 }
 
-func funcNumber(compiledFunc *vm.CompiledFunc, args []string) (vm.Instruction, string, string, error) {
+func funcNumber(compiledFunc *vm.CompiledFunc, args []vm.Register) (vm.Instruction, vm.Register, string, error) {
 	result := compiledFunc.NextRegister()
 	ins := &vm.CastNumber{
 		X:      args[0],
@@ -84,7 +88,7 @@ func funcNumber(compiledFunc *vm.CompiledFunc, args []string) (vm.Instruction, s
 	return ins, result, "number", nil
 }
 
-func funcString(compiledFunc *vm.CompiledFunc, args []string) (vm.Instruction, string, string, error) {
+func funcString(compiledFunc *vm.CompiledFunc, args []vm.Register) (vm.Instruction, vm.Register, string, error) {
 	result := compiledFunc.NextRegister()
 	ins := &vm.CastString{
 		X:      args[0],
@@ -94,7 +98,7 @@ func funcString(compiledFunc *vm.CompiledFunc, args []string) (vm.Instruction, s
 	return ins, result, "string", nil
 }
 
-func funcChar(compiledFunc *vm.CompiledFunc, args []string) (vm.Instruction, string, string, error) {
+func funcChar(compiledFunc *vm.CompiledFunc, args []vm.Register) (vm.Instruction, vm.Register, string, error) {
 	result := compiledFunc.NextRegister()
 	ins := &vm.CastChar{
 		X:      args[0],
@@ -104,7 +108,7 @@ func funcChar(compiledFunc *vm.CompiledFunc, args []string) (vm.Instruction, str
 	return ins, result, "char", nil
 }
 
-func funcLog(compiledFunc *vm.CompiledFunc, args []string) (vm.Instruction, string, string, error) {
+func funcLog(compiledFunc *vm.CompiledFunc, args []vm.Register) (vm.Instruction, vm.Register, string, error) {
 	result := compiledFunc.NextRegister()
 	ins := &vm.Log{
 		X:      args[0],
@@ -114,7 +118,7 @@ func funcLog(compiledFunc *vm.CompiledFunc, args []string) (vm.Instruction, stri
 	return ins, result, "number", nil
 }
 
-func funcPow(compiledFunc *vm.CompiledFunc, args []string) (vm.Instruction, string, string, error) {
+func funcPow(compiledFunc *vm.CompiledFunc, args []vm.Register) (vm.Instruction, vm.Register, string, error) {
 	result := compiledFunc.NextRegister()
 	ins := &vm.Power{
 		Base:   args[0],
@@ -125,7 +129,7 @@ func funcPow(compiledFunc *vm.CompiledFunc, args []string) (vm.Instruction, stri
 	return ins, result, "number", nil
 }
 
-func funcLen(compiledFunc *vm.CompiledFunc, args []string) (vm.Instruction, string, string, error) {
+func funcLen(compiledFunc *vm.CompiledFunc, args []vm.Register) (vm.Instruction, vm.Register, string, error) {
 	result := compiledFunc.NextRegister()
 	ins := &vm.Len{
 		Argument: args[0],
@@ -135,7 +139,7 @@ func funcLen(compiledFunc *vm.CompiledFunc, args []string) (vm.Instruction, stri
 	return ins, result, "number", nil
 }
 
-func funcPrint(compiledFunc *vm.CompiledFunc, args []string) (vm.Instruction, string, string, error) {
+func funcPrint(_ *vm.CompiledFunc, args []vm.Register) (vm.Instruction, vm.Register, string, error) {
 	ins := &vm.Print{
 		Arguments: args,
 	}

--- a/compiler/call_test.go
+++ b/compiler/call_test.go
@@ -80,7 +80,7 @@ func TestCall(t *testing.T) {
 					Register:     "1",
 				},
 				&vm.Print{
-					Arguments: []string{"foo"},
+					Arguments: []vm.Register{"foo"},
 				},
 			},
 		},
@@ -138,7 +138,7 @@ func TestCall(t *testing.T) {
 					Result: "5",
 				},
 				&vm.Print{
-					Arguments: []string{"3", "5"},
+					Arguments: []vm.Register{"3", "5"},
 				},
 			},
 		},

--- a/compiler/expr.go
+++ b/compiler/expr.go
@@ -8,7 +8,11 @@ import (
 )
 
 // compileExpr return the (result register, result type, error)
-func compileExpr(compiledFunc *vm.CompiledFunc, expr ast.Node, fns map[string]*ast.Func) ([]string, []string, error) {
+func compileExpr(
+	compiledFunc *vm.CompiledFunc,
+	expr ast.Node,
+	fns map[string]*ast.Func,
+) ([]vm.Register, []string, error) {
 	switch e := expr.(type) {
 	case *ast.Assign:
 		err := compileAssign(compiledFunc, e, fns)
@@ -22,7 +26,7 @@ func compileExpr(compiledFunc *vm.CompiledFunc, expr ast.Node, fns map[string]*a
 			Value:        e,
 		})
 
-		return []string{returns}, []string{e.Kind}, nil
+		return []vm.Register{returns}, []string{e.Kind}, nil
 
 	case *ast.Array:
 		returns, kind, err := compileArray(compiledFunc, e, fns)
@@ -30,7 +34,7 @@ func compileExpr(compiledFunc *vm.CompiledFunc, expr ast.Node, fns map[string]*a
 			return nil, nil, err
 		}
 
-		return []string{returns}, []string{kind}, nil
+		return []vm.Register{returns}, []string{kind}, nil
 
 	case *ast.Map:
 		returns, err := compileMap(compiledFunc, e, fns)
@@ -39,7 +43,7 @@ func compileExpr(compiledFunc *vm.CompiledFunc, expr ast.Node, fns map[string]*a
 		}
 
 		// TODO(elliot): Doesn't return type.
-		return []string{returns}, []string{"{}"}, nil
+		return []vm.Register{returns}, []string{"{}"}, nil
 
 	case *ast.Call:
 		results, resultKinds, err := compileCall(compiledFunc, e, fns)
@@ -52,7 +56,7 @@ func compileExpr(compiledFunc *vm.CompiledFunc, expr ast.Node, fns map[string]*a
 
 	case *ast.Identifier:
 		if v, ok := compiledFunc.Variables[e.Name]; ok {
-			return []string{e.Name}, []string{v}, nil
+			return []vm.Register{vm.Register(e.Name)}, []string{v}, nil
 		}
 
 		return nil, nil, fmt.Errorf("undefined variable: %s", e.Name)
@@ -63,7 +67,7 @@ func compileExpr(compiledFunc *vm.CompiledFunc, expr ast.Node, fns map[string]*a
 			return nil, nil, err
 		}
 
-		return []string{result}, []string{ty}, nil
+		return []vm.Register{result}, []string{ty}, nil
 
 	case *ast.Group:
 		return compileExpr(compiledFunc, e.Expr, fns)
@@ -74,7 +78,7 @@ func compileExpr(compiledFunc *vm.CompiledFunc, expr ast.Node, fns map[string]*a
 			return nil, nil, err
 		}
 
-		return []string{result}, []string{ty}, nil
+		return []vm.Register{result}, []string{ty}, nil
 
 	case *ast.Key:
 		result, ty, err := compileKey(compiledFunc, e, fns)
@@ -82,7 +86,7 @@ func compileExpr(compiledFunc *vm.CompiledFunc, expr ast.Node, fns map[string]*a
 			return nil, nil, err
 		}
 
-		return []string{result}, []string{ty}, nil
+		return []vm.Register{result}, []string{ty}, nil
 
 	case *ast.Interpolate:
 		result, err := compileInterpolate(compiledFunc, e, fns)
@@ -90,7 +94,7 @@ func compileExpr(compiledFunc *vm.CompiledFunc, expr ast.Node, fns map[string]*a
 			return nil, nil, err
 		}
 
-		return []string{result}, []string{"string"}, nil
+		return []vm.Register{result}, []string{"string"}, nil
 	}
 
 	panic(expr)

--- a/compiler/file_test.go
+++ b/compiler/file_test.go
@@ -119,7 +119,7 @@ func TestCompileFile(t *testing.T) {
 							},
 							&vm.Call{
 								FunctionName: "add",
-								Arguments:    []string{"1"},
+								Arguments:    []vm.Register{"1"},
 							},
 						},
 					},
@@ -131,7 +131,7 @@ func TestCompileFile(t *testing.T) {
 						Registers: 1,
 						Instructions: []vm.Instruction{
 							&vm.Print{
-								Arguments: []string{"x"},
+								Arguments: []vm.Register{"x"},
 							},
 						},
 					},
@@ -234,7 +234,7 @@ func TestCompileFile(t *testing.T) {
 						Instructions: []vm.Instruction{
 							&vm.Call{
 								FunctionName: "Person",
-								Results:      []string{"1"},
+								Results:      []vm.Register{"1"},
 							},
 							&vm.Assign{
 								VariableName: "p",
@@ -263,7 +263,7 @@ func TestCompileFile(t *testing.T) {
 
 							// return instance
 							&vm.Return{
-								Results: []string{"2"},
+								Results: []vm.Register{"2"},
 							},
 						},
 					},

--- a/compiler/for.go
+++ b/compiler/for.go
@@ -19,7 +19,7 @@ func compileFor(compiledFunc *vm.CompiledFunc, n *ast.For, fns map[string]*ast.F
 		}
 	}
 
-	var conditionResults []string
+	var conditionResults []vm.Register
 	switch cond := n.Condition.(type) {
 	case nil:
 		// Error here should not be possible.
@@ -62,14 +62,14 @@ func compileFor(compiledFunc *vm.CompiledFunc, n *ast.For, fns map[string]*ast.F
 			Value:        asttest.NewLiteralNumber("0"),
 		})
 
-		conditionResults = []string{compiledFunc.NextRegister()}
+		conditionResults = []vm.Register{compiledFunc.NextRegister()}
 		switch {
 		case kind.IsArray(arrayOrMapKind[0]):
 			compiledFunc.Append(&vm.NextArray{
 				Array:       arrayOrMapResults[0],
 				Cursor:      cursorRegister,
-				KeyResult:   cond.Key,
-				ValueResult: cond.Value,
+				KeyResult:   vm.Register(cond.Key),
+				ValueResult: vm.Register(cond.Value),
 				Result:      conditionResults[0],
 			})
 
@@ -77,17 +77,17 @@ func compileFor(compiledFunc *vm.CompiledFunc, n *ast.For, fns map[string]*ast.F
 			compiledFunc.Append(&vm.NextMap{
 				Map:         arrayOrMapResults[0],
 				Cursor:      cursorRegister,
-				KeyResult:   cond.Key,
-				ValueResult: cond.Value,
+				KeyResult:   vm.Register(cond.Key),
+				ValueResult: vm.Register(cond.Value),
 				Result:      conditionResults[0],
 			})
 
 		case arrayOrMapKind[0] == "string":
 			compiledFunc.Append(&vm.NextString{
-				String:      arrayOrMapResults[0],
+				Str:         arrayOrMapResults[0],
 				Cursor:      cursorRegister,
-				KeyResult:   cond.Key,
-				ValueResult: cond.Value,
+				KeyResult:   vm.Register(cond.Key),
+				ValueResult: vm.Register(cond.Value),
 				Result:      conditionResults[0],
 			})
 		}

--- a/compiler/for_test.go
+++ b/compiler/for_test.go
@@ -412,7 +412,7 @@ func TestFor(t *testing.T) {
 
 				// print(a)
 				&vm.Print{
-					Arguments: []string{"a"},
+					Arguments: []vm.Register{"a"},
 				},
 
 				// ++a

--- a/compiler/func.go
+++ b/compiler/func.go
@@ -53,7 +53,7 @@ func CompileFunc(fn *ast.Func, fns map[string]*ast.Func) (*vm.CompiledFunc, erro
 	// If this is an object, always returns its state.
 	if isObject {
 		compiled.Append(&vm.Return{
-			Results: []string{compiled.ObjectRegister},
+			Results: []vm.Register{compiled.ObjectRegister},
 		})
 	}
 

--- a/compiler/func_test.go
+++ b/compiler/func_test.go
@@ -53,7 +53,7 @@ func TestFunc(t *testing.T) {
 					Value:        asttest.NewLiteralString("hello"),
 				},
 				&vm.Print{
-					Arguments: []string{"1"},
+					Arguments: []vm.Register{"1"},
 				},
 			},
 		},

--- a/compiler/interpolate.go
+++ b/compiler/interpolate.go
@@ -5,7 +5,11 @@ import (
 	"github.com/elliotchance/ok/vm"
 )
 
-func compileInterpolate(compiledFunc *vm.CompiledFunc, n *ast.Interpolate, fns map[string]*ast.Func) (string, error) {
+func compileInterpolate(
+	compiledFunc *vm.CompiledFunc,
+	n *ast.Interpolate,
+	fns map[string]*ast.Func,
+) (vm.Register, error) {
 	ins := &vm.Interpolate{
 		Result: compiledFunc.NextRegister(),
 	}

--- a/compiler/interpolate_test.go
+++ b/compiler/interpolate_test.go
@@ -55,7 +55,7 @@ func TestInterpolate(t *testing.T) {
 				},
 				&vm.Interpolate{
 					Result: "1",
-					Args:   []string{"2", "5", "6"},
+					Args:   []vm.Register{"2", "5", "6"},
 				},
 			},
 		},

--- a/compiler/key.go
+++ b/compiler/key.go
@@ -7,7 +7,7 @@ import (
 	"github.com/elliotchance/ok/vm"
 )
 
-func compileKey(compiledFunc *vm.CompiledFunc, n *ast.Key, fns map[string]*ast.Func) (string, string, error) {
+func compileKey(compiledFunc *vm.CompiledFunc, n *ast.Key, fns map[string]*ast.Func) (vm.Register, string, error) {
 	arrayOrMapRegisters, arrayOrMapKind, err := compileExpr(compiledFunc, n.Expr, fns)
 	if err != nil {
 		return "", "", err
@@ -30,7 +30,7 @@ func compileKey(compiledFunc *vm.CompiledFunc, n *ast.Key, fns map[string]*ast.F
 
 	case arrayOrMapKind[0] == "string":
 		compiledFunc.Append(&vm.StringIndex{
-			String: arrayOrMapRegisters[0],
+			Str:    arrayOrMapRegisters[0],
 			Index:  keyRegisters[0],
 			Result: resultRegister,
 		})

--- a/compiler/key_test.go
+++ b/compiler/key_test.go
@@ -487,7 +487,7 @@ func TestKey(t *testing.T) {
 					Value:        asttest.NewLiteralNumber("1"),
 				},
 				&vm.StringIndex{
-					String: "foo",
+					Str:    "foo",
 					Index:  "2",
 					Result: "3",
 				},

--- a/compiler/map.go
+++ b/compiler/map.go
@@ -8,7 +8,11 @@ import (
 	"github.com/elliotchance/ok/vm"
 )
 
-func compileMap(compiledFunc *vm.CompiledFunc, n *ast.Map, fns map[string]*ast.Func) (string, error) {
+func compileMap(
+	compiledFunc *vm.CompiledFunc,
+	n *ast.Map,
+	fns map[string]*ast.Func,
+) (vm.Register, error) {
 	// TODO(elliot): Check type is valid for the map.
 	// TODO(elliot): Maps with duplicate keys should be an error.
 

--- a/compiler/object_test.go
+++ b/compiler/object_test.go
@@ -35,7 +35,7 @@ func TestObject(t *testing.T) {
 
 				// return instance
 				&vm.Return{
-					Results: []string{"2"},
+					Results: []vm.Register{"2"},
 				},
 			},
 		},
@@ -82,7 +82,7 @@ func TestObject(t *testing.T) {
 
 				// return instance
 				&vm.Return{
-					Results: []string{"2"},
+					Results: []vm.Register{"2"},
 				},
 			},
 		},

--- a/compiler/return.go
+++ b/compiler/return.go
@@ -6,7 +6,7 @@ import (
 )
 
 func compileReturn(compiledFunc *vm.CompiledFunc, n *ast.Return, fns map[string]*ast.Func) error {
-	var results []string
+	var results []vm.Register
 	for _, expr := range n.Exprs {
 		// TODO(elliot): Check return types are valid.
 		result, _, err := compileExpr(compiledFunc, expr, fns)

--- a/compiler/return_test.go
+++ b/compiler/return_test.go
@@ -35,7 +35,7 @@ func TestReturn(t *testing.T) {
 					Value:        asttest.NewLiteralNumber("123"),
 				},
 				&vm.Return{
-					Results: []string{"1"},
+					Results: []vm.Register{"1"},
 				},
 			},
 		},
@@ -56,7 +56,7 @@ func TestReturn(t *testing.T) {
 					Value:        asttest.NewLiteralString("foo"),
 				},
 				&vm.Return{
-					Results: []string{"1", "2"},
+					Results: []vm.Register{"1", "2"},
 				},
 			},
 		},

--- a/compiler/switch.go
+++ b/compiler/switch.go
@@ -7,7 +7,14 @@ import (
 	"github.com/elliotchance/ok/vm"
 )
 
-func compileCase(compiledFunc *vm.CompiledFunc, n *ast.Case, valueRegister, expectedConditionKind string, afterMatch, breakIns, continueIns vm.Instruction, fns map[string]*ast.Func) error {
+func compileCase(
+	compiledFunc *vm.CompiledFunc,
+	n *ast.Case,
+	valueRegister vm.Register,
+	expectedConditionKind string,
+	afterMatch, breakIns, continueIns vm.Instruction,
+	fns map[string]*ast.Func,
+) error {
 	// TODO(elliot): This is a poor solution. It simply expands the conditions
 	//  out as if they were individual case statements. This duplicates
 	//  statements and uses more memory.
@@ -32,7 +39,7 @@ func compileCase(compiledFunc *vm.CompiledFunc, n *ast.Case, valueRegister, expe
 			bop, _ := getBinaryInstruction(op, valueRegister, conditionResults[0], result)
 			compiledFunc.Append(bop)
 
-			conditionResults = []string{result}
+			conditionResults = []vm.Register{result}
 		}
 
 		ins := &vm.JumpUnless{
@@ -64,7 +71,7 @@ func compileSwitch(compiledFunc *vm.CompiledFunc, n *ast.Switch, breakIns, conti
 	// Condition must be a bool if no value has been provided, otherwise all
 	// conditions must be the same type as the value.
 	expectedConditionKinds := []string{"bool"}
-	valueRegisters := []string{""}
+	valueRegisters := []vm.Register{""}
 	if n.Expr != nil {
 		var err error
 		valueRegisters, expectedConditionKinds, err = compileExpr(compiledFunc, n.Expr, fns)

--- a/compiler/switch_test.go
+++ b/compiler/switch_test.go
@@ -105,7 +105,7 @@ func TestSwitch(t *testing.T) {
 					Value:        asttest.NewLiteralString("ONE"),
 				},
 				&vm.Print{
-					Arguments: []string{"4"},
+					Arguments: []vm.Register{"4"},
 				},
 				&vm.Jump{
 					To: 13,
@@ -132,7 +132,7 @@ func TestSwitch(t *testing.T) {
 					Value:        asttest.NewLiteralString("TWO"),
 				},
 				&vm.Print{
-					Arguments: []string{"7"},
+					Arguments: []vm.Register{"7"},
 				},
 				&vm.Jump{
 					To: 13,
@@ -228,7 +228,7 @@ func TestSwitch(t *testing.T) {
 					Value:        asttest.NewLiteralString("ONE"),
 				},
 				&vm.Print{
-					Arguments: []string{"4"},
+					Arguments: []vm.Register{"4"},
 				},
 				&vm.Jump{
 					To: 15,
@@ -255,7 +255,7 @@ func TestSwitch(t *testing.T) {
 					Value:        asttest.NewLiteralString("TWO"),
 				},
 				&vm.Print{
-					Arguments: []string{"7"},
+					Arguments: []vm.Register{"7"},
 				},
 				&vm.Jump{
 					To: 15,
@@ -267,7 +267,7 @@ func TestSwitch(t *testing.T) {
 					Value:        asttest.NewLiteralString("NO MATCH"),
 				},
 				&vm.Print{
-					Arguments: []string{"8"},
+					Arguments: []vm.Register{"8"},
 				},
 			},
 		},
@@ -357,7 +357,7 @@ func TestSwitch(t *testing.T) {
 					Value:        asttest.NewLiteralString("ONE OR TWO"),
 				},
 				&vm.Print{
-					Arguments: []string{"4"},
+					Arguments: []vm.Register{"4"},
 				},
 				&vm.Jump{
 					To: 19,
@@ -384,7 +384,7 @@ func TestSwitch(t *testing.T) {
 					Value:        asttest.NewLiteralString("ONE OR TWO"),
 				},
 				&vm.Print{
-					Arguments: []string{"7"},
+					Arguments: []vm.Register{"7"},
 				},
 				&vm.Jump{
 					To: 19,
@@ -411,7 +411,7 @@ func TestSwitch(t *testing.T) {
 					Value:        asttest.NewLiteralString("THREE"),
 				},
 				&vm.Print{
-					Arguments: []string{"10"},
+					Arguments: []vm.Register{"10"},
 				},
 				&vm.Jump{
 					To: 19,
@@ -519,7 +519,7 @@ func TestSwitch(t *testing.T) {
 					Value:        asttest.NewLiteralString("ONE OR TWO"),
 				},
 				&vm.Print{
-					Arguments: []string{"4"},
+					Arguments: []vm.Register{"4"},
 				},
 				&vm.Jump{
 					To: 19,
@@ -546,7 +546,7 @@ func TestSwitch(t *testing.T) {
 					Value:        asttest.NewLiteralString("ONE OR TWO"),
 				},
 				&vm.Print{
-					Arguments: []string{"7"},
+					Arguments: []vm.Register{"7"},
 				},
 				&vm.Jump{
 					To: 19,
@@ -573,7 +573,7 @@ func TestSwitch(t *testing.T) {
 					Value:        asttest.NewLiteralString("THREE"),
 				},
 				&vm.Print{
-					Arguments: []string{"10"},
+					Arguments: []vm.Register{"10"},
 				},
 				&vm.Jump{
 					To: 19,

--- a/compiler/unary.go
+++ b/compiler/unary.go
@@ -6,7 +6,7 @@ import (
 	"github.com/elliotchance/ok/vm"
 )
 
-func compileUnary(compiledFunc *vm.CompiledFunc, e *ast.Unary, fns map[string]*ast.Func) (string, string, error) {
+func compileUnary(compiledFunc *vm.CompiledFunc, e *ast.Unary, fns map[string]*ast.Func) (vm.Register, string, error) {
 	returns1, kinds, err := compileExpr(compiledFunc, e.Expr, fns)
 	if err != nil {
 		return "", "", err
@@ -49,9 +49,9 @@ func compileUnary(compiledFunc *vm.CompiledFunc, e *ast.Unary, fns map[string]*a
 		})
 
 		ins = &vm.Add{
-			Left:   returns1[0],
-			Right:  oneAt,
-			Result: returns1[0],
+			Left:   vm.Register(returns1[0]),
+			Right:  vm.Register(oneAt),
+			Result: vm.Register(returns1[0]),
 		}
 		compiledFunc.Append(ins)
 

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sort"
 
+	"github.com/elliotchance/ok/cmd/asm"
 	"github.com/elliotchance/ok/cmd/build"
 	"github.com/elliotchance/ok/cmd/doc"
 	"github.com/elliotchance/ok/cmd/run"
@@ -20,6 +21,7 @@ type command interface {
 }
 
 var commands = map[string]command{
+	"asm":     &asm.Command{},
 	"build":   &build.Command{},
 	"doc":     &doc.Command{},
 	"run":     &run.Command{},

--- a/vm/add.go
+++ b/vm/add.go
@@ -1,6 +1,8 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/number"
@@ -8,11 +10,11 @@ import (
 
 // Add will sum two numbers.
 type Add struct {
-	Left, Right, Result string
+	Left, Right, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Add) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *Add) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	registers[ins.Result] = asttest.NewLiteralNumber(
 		number.Add(
 			number.NewNumber(registers[ins.Left].Value),
@@ -21,4 +23,9 @@ func (ins *Add) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error 
 	)
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *Add) String() string {
+	return fmt.Sprintf("%s = %s + %s", ins.Result, ins.Left, ins.Right)
 }

--- a/vm/add_test.go
+++ b/vm/add_test.go
@@ -18,7 +18,7 @@ func TestAdd_Execute(t *testing.T) {
 		"maintain-precision": {"1.2200", "4.7", "5.9200"},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			registers := map[string]*ast.Literal{
+			registers := map[vm.Register]*ast.Literal{
 				"0": asttest.NewLiteralNumber(test.left),
 				"1": asttest.NewLiteralNumber(test.right),
 			}
@@ -27,4 +27,9 @@ func TestAdd_Execute(t *testing.T) {
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}
+}
+
+func TestAdd_String(t *testing.T) {
+	ins := &vm.Add{Left: "0", Right: "1", Result: "2"}
+	assert.Equal(t, "$2 = $0 + $1", ins.String())
 }

--- a/vm/and.go
+++ b/vm/and.go
@@ -1,21 +1,28 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 )
 
 // And is a logical AND between two bools.
 type And struct {
-	Left, Right, Result string
+	Left, Right, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *And) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *And) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	registers[ins.Result] = asttest.NewLiteralBool(
 		(registers[ins.Left].Value == "true") &&
 			(registers[ins.Right].Value == "true"),
 	)
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *And) String() string {
+	return fmt.Sprintf("%s = %s and %s", ins.Result, ins.Left, ins.Right)
 }

--- a/vm/and_test.go
+++ b/vm/and_test.go
@@ -21,7 +21,7 @@ func TestAnd_Execute(t *testing.T) {
 		"true-true":   {true, true, "true"},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			registers := map[string]*ast.Literal{
+			registers := map[vm.Register]*ast.Literal{
 				"0": asttest.NewLiteralBool(test.left),
 				"1": asttest.NewLiteralBool(test.right),
 			}
@@ -30,4 +30,9 @@ func TestAnd_Execute(t *testing.T) {
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}
+}
+
+func TestAnd_String(t *testing.T) {
+	ins := &vm.And{Left: "0", Right: "1", Result: "2"}
+	assert.Equal(t, "$2 = $0 and $1", ins.String())
 }

--- a/vm/append.go
+++ b/vm/append.go
@@ -1,20 +1,27 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 )
 
 // Append returns an array by combining two other arrays.
 type Append struct {
-	A, B, Result string
+	A, B, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Append) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *Append) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	registers[ins.Result] = &ast.Literal{
 		Kind:  registers[ins.A].Kind,
 		Array: append(registers[ins.A].Array, registers[ins.B].Array...),
 	}
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *Append) String() string {
+	return fmt.Sprintf("%s = append(%s, %s)", ins.Result, ins.A, ins.B)
 }

--- a/vm/append_test.go
+++ b/vm/append_test.go
@@ -1,0 +1,13 @@
+package vm_test
+
+import (
+	"testing"
+
+	"github.com/elliotchance/ok/vm"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAppend_String(t *testing.T) {
+	ins := &vm.Append{A: "0", B: "1", Result: "2"}
+	assert.Equal(t, "$2 = append($0, $1)", ins.String())
+}

--- a/vm/array_alloc.go
+++ b/vm/array_alloc.go
@@ -1,18 +1,20 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/number"
 )
 
-// ArrayAlloc allocates a "[]number" of fixed size.
+// ArrayAlloc allocates an array of fixed size.
 type ArrayAlloc struct {
-	Size, Result string
+	Size, Result Register
 	Kind         string
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *ArrayAlloc) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *ArrayAlloc) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	size := number.Int64(number.NewNumber(registers[ins.Size].Value))
 
 	registers[ins.Result] = &ast.Literal{
@@ -21,4 +23,9 @@ func (ins *ArrayAlloc) Execute(registers map[string]*ast.Literal, _ *int, _ *VM)
 	}
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *ArrayAlloc) String() string {
+	return fmt.Sprintf("%s = %s with %s elements", ins.Result, ins.Kind, ins.Size)
 }

--- a/vm/array_alloc_test.go
+++ b/vm/array_alloc_test.go
@@ -1,0 +1,13 @@
+package vm_test
+
+import (
+	"testing"
+
+	"github.com/elliotchance/ok/vm"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestArrayAlloc_String(t *testing.T) {
+	ins := &vm.ArrayAlloc{Size: "0", Result: "1", Kind: "[]string"}
+	assert.Equal(t, "$1 = []string with $0 elements", ins.String())
+}

--- a/vm/array_get.go
+++ b/vm/array_get.go
@@ -1,19 +1,26 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/number"
 )
 
 // ArrayGet gets a value from the array by its index.
 type ArrayGet struct {
-	Array, Index, Result string
+	Array, Index, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *ArrayGet) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *ArrayGet) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	index := number.Int64(number.NewNumber(registers[ins.Index].Value))
 	registers[ins.Result] = registers[ins.Array].Array[index]
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *ArrayGet) String() string {
+	return fmt.Sprintf("%s = %s[%s]", ins.Result, ins.Array, ins.Index)
 }

--- a/vm/array_get_test.go
+++ b/vm/array_get_test.go
@@ -1,0 +1,13 @@
+package vm_test
+
+import (
+	"testing"
+
+	"github.com/elliotchance/ok/vm"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestArrayGet_String(t *testing.T) {
+	ins := &vm.ArrayGet{Array: "0", Index: "1", Result: "2"}
+	assert.Equal(t, "$2 = $0[$1]", ins.String())
+}

--- a/vm/array_set.go
+++ b/vm/array_set.go
@@ -1,19 +1,26 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/number"
 )
 
 // ArraySet sets a number value to an index.
 type ArraySet struct {
-	Array, Index, Value string
+	Array, Index, Value Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *ArraySet) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *ArraySet) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	index := number.Int64(number.NewNumber(registers[ins.Index].Value))
 	registers[ins.Array].Array[index] = registers[ins.Value]
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *ArraySet) String() string {
+	return fmt.Sprintf("%s[%s] = %s", ins.Array, ins.Index, ins.Value)
 }

--- a/vm/array_set_test.go
+++ b/vm/array_set_test.go
@@ -1,0 +1,13 @@
+package vm_test
+
+import (
+	"testing"
+
+	"github.com/elliotchance/ok/vm"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestArraySet_String(t *testing.T) {
+	ins := &vm.ArraySet{Array: "0", Index: "1", Value: "2"}
+	assert.Equal(t, "$0[$1] = $2", ins.String())
+}

--- a/vm/assert.go
+++ b/vm/assert.go
@@ -1,21 +1,29 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 )
 
 // Assert is used in tests.
 type Assert struct {
-	Left, Op, Right, Final string
-	Pos                    string
+	Left, Right, Final Register
+	Op                 string
+	Pos                string
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Assert) Execute(registers map[string]*ast.Literal, _ *int, vm *VM) error {
+func (ins *Assert) Execute(registers map[Register]*ast.Literal, _ *int, vm *VM) error {
 	pass := registers[ins.Final].Value == "true"
 	left := renderLiteral(registers[ins.Left], true)
 	right := renderLiteral(registers[ins.Right], true)
 	vm.assert(pass, left, ins.Op, right, ins.Pos)
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *Assert) String() string {
+	return fmt.Sprintf("assert(%s %s %s)", ins.Left, ins.Op, ins.Right)
 }

--- a/vm/assert_test.go
+++ b/vm/assert_test.go
@@ -1,0 +1,13 @@
+package vm_test
+
+import (
+	"testing"
+
+	"github.com/elliotchance/ok/vm"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAssert_String(t *testing.T) {
+	ins := &vm.Assert{Left: "0", Right: "1", Final: "2", Op: "==", Pos: "pos"}
+	assert.Equal(t, "assert($0 == $1)", ins.String())
+}

--- a/vm/assign.go
+++ b/vm/assign.go
@@ -1,18 +1,20 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 )
 
 // Assign sets a variable to the result of an expression.
 type Assign struct {
-	VariableName string
+	VariableName Register
 	Value        *ast.Literal
-	Register     string
+	Register     Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Assign) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *Assign) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	if ins.Value != nil {
 		registers[ins.VariableName] = ins.Value
 	} else {
@@ -20,4 +22,12 @@ func (ins *Assign) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) err
 	}
 
 	return nil
+}
+
+func (ins *Assign) String() string {
+	if ins.Value != nil {
+		return fmt.Sprintf("%s = %s", ins.VariableName, ins.Value)
+	}
+
+	return fmt.Sprintf("%s = %s", ins.VariableName, ins.Register)
 }

--- a/vm/assign_test.go
+++ b/vm/assign_test.go
@@ -12,14 +12,14 @@ import (
 
 func TestAssign_Execute(t *testing.T) {
 	t.Run("literal", func(t *testing.T) {
-		registers := map[string]*ast.Literal{}
+		registers := map[vm.Register]*ast.Literal{}
 		ins := &vm.Assign{VariableName: "1", Value: asttest.NewLiteralNumber("1.5")}
 		assert.NoError(t, ins.Execute(registers, nil, nil))
 		assert.Equal(t, "1.5", registers["1"].Value)
 	})
 
 	t.Run("register", func(t *testing.T) {
-		registers := map[string]*ast.Literal{
+		registers := map[vm.Register]*ast.Literal{
 			"0": asttest.NewLiteralNumber("1.5"),
 		}
 		ins := &vm.Assign{VariableName: "1", Register: "0"}

--- a/vm/call.go
+++ b/vm/call.go
@@ -1,18 +1,20 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 )
 
 // Call tells the VM to jump to another function.
 type Call struct {
 	FunctionName string
-	Arguments    []string
-	Results      []string
+	Arguments    Registers
+	Results      Registers
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Call) Execute(registers map[string]*ast.Literal, i *int, vm *VM) error {
+func (ins *Call) Execute(registers map[Register]*ast.Literal, i *int, vm *VM) error {
 	results, err := vm.call(ins.FunctionName, ins.Arguments)
 	if err != nil {
 		return err
@@ -31,4 +33,9 @@ func (ins *Call) Execute(registers map[string]*ast.Literal, i *int, vm *VM) erro
 	vm.Return = nil
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *Call) String() string {
+	return fmt.Sprintf("%s = %s%s", ins.Results, ins.FunctionName, ins.Arguments)
 }

--- a/vm/call_test.go
+++ b/vm/call_test.go
@@ -1,0 +1,17 @@
+package vm_test
+
+import (
+	"testing"
+
+	"github.com/elliotchance/ok/vm"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCall_String(t *testing.T) {
+	ins := &vm.Call{
+		FunctionName: "foo",
+		Arguments:    []vm.Register{"1", "2"},
+		Results:      []vm.Register{"4", "5"},
+	}
+	assert.Equal(t, "($4, $5) = foo($1, $2)", ins.String())
+}

--- a/vm/cast.go
+++ b/vm/cast.go
@@ -9,11 +9,11 @@ import (
 
 // CastString returns a string value of a value.
 type CastString struct {
-	X, Result string
+	X, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *CastString) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *CastString) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	registers[ins.Result] = &ast.Literal{
 		Kind:  "string",
 		Value: renderLiteral(registers[ins.X], false),
@@ -22,13 +22,18 @@ func (ins *CastString) Execute(registers map[string]*ast.Literal, _ *int, _ *VM)
 	return nil
 }
 
+// String is the human-readable description of the instruction.
+func (ins *CastString) String() string {
+	return fmt.Sprintf("%s = string %s", ins.Result, ins.X)
+}
+
 // CastNumber returns a number value of a value.
 type CastNumber struct {
-	X, Result string
+	X, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *CastNumber) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *CastNumber) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	registers[ins.Result] = &ast.Literal{
 		Kind:  "number",
 		Value: fmt.Sprintf("%d", int([]rune(registers[ins.X].Value)[0])),
@@ -37,17 +42,27 @@ func (ins *CastNumber) Execute(registers map[string]*ast.Literal, _ *int, _ *VM)
 	return nil
 }
 
+// String is the human-readable description of the instruction.
+func (ins *CastNumber) String() string {
+	return fmt.Sprintf("%s = number %s", ins.Result, ins.X)
+}
+
 // CastChar returns a char value of a value.
 type CastChar struct {
-	X, Result string
+	X, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *CastChar) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *CastChar) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	registers[ins.Result] = &ast.Literal{
 		Kind:  "char",
 		Value: fmt.Sprintf("%c", number.Int(number.NewNumber(registers[ins.X].Value))),
 	}
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *CastChar) String() string {
+	return fmt.Sprintf("%s = char %s", ins.Result, ins.X)
 }

--- a/vm/cast_test.go
+++ b/vm/cast_test.go
@@ -1,0 +1,23 @@
+package vm_test
+
+import (
+	"testing"
+
+	"github.com/elliotchance/ok/vm"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCastString_String(t *testing.T) {
+	ins := &vm.CastString{X: "1", Result: "2"}
+	assert.Equal(t, "$2 = string $1", ins.String())
+}
+
+func TestCastNumber_String(t *testing.T) {
+	ins := &vm.CastNumber{X: "1", Result: "2"}
+	assert.Equal(t, "$2 = number $1", ins.String())
+}
+
+func TestCastChar_String(t *testing.T) {
+	ins := &vm.CastChar{X: "1", Result: "2"}
+	assert.Equal(t, "$2 = char $1", ins.String())
+}

--- a/vm/combine.go
+++ b/vm/combine.go
@@ -1,19 +1,26 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 )
 
 // Combine will create a new data by joining two other datas.
 type Combine struct {
-	Left, Right, Result string
+	Left, Right, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Combine) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *Combine) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	registers[ins.Result] = asttest.NewLiteralData(
 		[]byte(registers[ins.Left].Value + registers[ins.Right].Value))
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *Combine) String() string {
+	return fmt.Sprintf("%s = combine(%s, %s)", ins.Result, ins.Left, ins.Right)
 }

--- a/vm/combine_test.go
+++ b/vm/combine_test.go
@@ -19,7 +19,7 @@ func TestCombine_Execute(t *testing.T) {
 		"both-non-empty": {[]byte("foo"), []byte("bar"), "foobar"},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			registers := map[string]*ast.Literal{
+			registers := map[vm.Register]*ast.Literal{
 				"0": asttest.NewLiteralData(test.left),
 				"1": asttest.NewLiteralData(test.right),
 			}
@@ -28,4 +28,9 @@ func TestCombine_Execute(t *testing.T) {
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}
+}
+
+func TestCombine_String(t *testing.T) {
+	ins := &vm.Combine{Left: "1", Right: "2", Result: "3"}
+	assert.Equal(t, "$3 = combine($1, $2)", ins.String())
 }

--- a/vm/concat.go
+++ b/vm/concat.go
@@ -1,19 +1,26 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 )
 
 // Concat will create a new string by joining two other strings.
 type Concat struct {
-	Left, Right, Result string
+	Left, Right, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Concat) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *Concat) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	registers[ins.Result] = asttest.NewLiteralString(
 		registers[ins.Left].Value + registers[ins.Right].Value)
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *Concat) String() string {
+	return fmt.Sprintf("%s = concat(%s, %s)", ins.Result, ins.Left, ins.Right)
 }

--- a/vm/concat_test.go
+++ b/vm/concat_test.go
@@ -19,7 +19,7 @@ func TestConcat_Execute(t *testing.T) {
 		"both-non-empty": {"foo", "bar", "foobar"},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			registers := map[string]*ast.Literal{
+			registers := map[vm.Register]*ast.Literal{
 				"0": asttest.NewLiteralString(test.left),
 				"1": asttest.NewLiteralString(test.right),
 			}
@@ -28,4 +28,9 @@ func TestConcat_Execute(t *testing.T) {
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}
+}
+
+func TestConcat_String(t *testing.T) {
+	ins := &vm.Concat{Left: "1", Right: "2", Result: "3"}
+	assert.Equal(t, "$3 = concat($1, $2)", ins.String())
 }

--- a/vm/divide.go
+++ b/vm/divide.go
@@ -1,6 +1,8 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/number"
@@ -8,11 +10,11 @@ import (
 
 // Divide will multiply two numbers.
 type Divide struct {
-	Left, Right, Result string
+	Left, Right, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Divide) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *Divide) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	divide, err := number.Divide(
 		number.NewNumber(registers[ins.Left].Value),
 		number.NewNumber(registers[ins.Right].Value),
@@ -25,4 +27,9 @@ func (ins *Divide) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) err
 
 	registers[ins.Result] = asttest.NewLiteralNumber(divide.String())
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *Divide) String() string {
+	return fmt.Sprintf("%s = %s / %s", ins.Result, ins.Left, ins.Right)
 }

--- a/vm/divide_test.go
+++ b/vm/divide_test.go
@@ -22,7 +22,7 @@ func TestDivide_Execute(t *testing.T) {
 		"divide-zero": {"1.2200", "0", "0", errors.New("division by zero")},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			registers := map[string]*ast.Literal{
+			registers := map[vm.Register]*ast.Literal{
 				"0": asttest.NewLiteralNumber(test.left),
 				"1": asttest.NewLiteralNumber(test.right),
 			}
@@ -32,4 +32,9 @@ func TestDivide_Execute(t *testing.T) {
 			assert.Equal(t, test.expected, number.Format(actual, -1))
 		})
 	}
+}
+
+func TestDivide_String(t *testing.T) {
+	ins := &vm.Divide{Left: "1", Right: "2", Result: "3"}
+	assert.Equal(t, "$3 = $1 / $2", ins.String())
 }

--- a/vm/equal.go
+++ b/vm/equal.go
@@ -1,6 +1,8 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/compiler/kind"
@@ -9,17 +11,22 @@ import (
 
 // EqualNumber will compare two numbers for equality.
 type EqualNumber struct {
-	Left, Right, Result string
+	Left, Right, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *EqualNumber) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *EqualNumber) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	registers[ins.Result] = asttest.NewLiteralBool(numbersAreEqual(
 		registers[ins.Left],
 		registers[ins.Right],
 	))
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *EqualNumber) String() string {
+	return fmt.Sprintf("%s = %s == %s", ins.Result, ins.Left, ins.Right)
 }
 
 func numbersAreEqual(a, b *ast.Literal) bool {
@@ -33,15 +40,20 @@ func numbersAreEqual(a, b *ast.Literal) bool {
 // type because every other type is stored as a string. When optimizations are
 // made in the future this will need to be expanded to one instruction per type.
 type Equal struct {
-	Left, Right, Result string
+	Left, Right, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Equal) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *Equal) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	registers[ins.Result] = asttest.NewLiteralBool(compareValue(
 		registers[ins.Left], registers[ins.Right]))
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *Equal) String() string {
+	return fmt.Sprintf("%s = %s == %s", ins.Result, ins.Left, ins.Right)
 }
 
 func compareValue(a, b *ast.Literal) bool {

--- a/vm/equal_test.go
+++ b/vm/equal_test.go
@@ -45,7 +45,7 @@ func TestEqual_Execute(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			registers := map[string]*ast.Literal{
+			registers := map[vm.Register]*ast.Literal{
 				"0": test.left,
 				"1": test.right,
 			}
@@ -70,7 +70,7 @@ func TestEqualNumber_Execute(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			registers := map[string]*ast.Literal{
+			registers := map[vm.Register]*ast.Literal{
 				"0": test.left,
 				"1": test.right,
 			}
@@ -79,4 +79,14 @@ func TestEqualNumber_Execute(t *testing.T) {
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}
+}
+
+func TestEqual_String(t *testing.T) {
+	ins := &vm.Equal{Left: "1", Right: "2", Result: "3"}
+	assert.Equal(t, "$3 = $1 == $2", ins.String())
+}
+
+func TestEqualNumber_String(t *testing.T) {
+	ins := &vm.EqualNumber{Left: "1", Right: "2", Result: "3"}
+	assert.Equal(t, "$3 = $1 == $2", ins.String())
 }

--- a/vm/error_scope.go
+++ b/vm/error_scope.go
@@ -1,6 +1,8 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 )
 
@@ -14,8 +16,13 @@ type On struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *On) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *On) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	// Nothing happens here because On is just a pragma for the VM to look
 	// forward to find the error handler.
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *On) String() string {
+	return fmt.Sprintf("on %s", ins.Type)
 }

--- a/vm/finally.go
+++ b/vm/finally.go
@@ -1,6 +1,8 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 )
 
@@ -11,8 +13,13 @@ type Finally struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Finally) Execute(registers map[string]*ast.Literal, _ *int, vm *VM) error {
+func (ins *Finally) Execute(registers map[Register]*ast.Literal, _ *int, vm *VM) error {
 	vm.FinallyBlocks[len(vm.FinallyBlocks)-1][ins.Index].Run = ins.Run
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *Finally) String() string {
+	return fmt.Sprintf("finally %d", ins.Index)
 }

--- a/vm/func.go
+++ b/vm/func.go
@@ -6,8 +6,8 @@ type CompiledFunc struct {
 	Arguments      []string
 	Instructions   []Instruction
 	Registers      int
-	Variables      map[string]string
-	ObjectRegister string
+	Variables      map[string]string // name: type
+	ObjectRegister Register
 	Finally        [][]Instruction
 }
 
@@ -16,9 +16,10 @@ type FinallyBlock struct {
 	Instructions []Instruction
 }
 
-func (c *CompiledFunc) NextRegister() string {
+func (c *CompiledFunc) NextRegister() Register {
 	c.Registers++
-	return fmt.Sprintf("%d", c.Registers)
+
+	return Register(fmt.Sprintf("%d", c.Registers))
 }
 
 func (c *CompiledFunc) Append(instruction Instruction) {

--- a/vm/greater_than.go
+++ b/vm/greater_than.go
@@ -1,6 +1,8 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/number"
@@ -8,11 +10,11 @@ import (
 
 // GreaterThanNumber will compare two numbers.
 type GreaterThanNumber struct {
-	Left, Right, Result string
+	Left, Right, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *GreaterThanNumber) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *GreaterThanNumber) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	registers[ins.Result] = asttest.NewLiteralBool(number.Cmp(
 		number.NewNumber(registers[ins.Left].Value),
 		number.NewNumber(registers[ins.Right].Value),
@@ -21,16 +23,26 @@ func (ins *GreaterThanNumber) Execute(registers map[string]*ast.Literal, _ *int,
 	return nil
 }
 
+// String is the human-readable description of the instruction.
+func (ins *GreaterThanNumber) String() string {
+	return fmt.Sprintf("%s = %s > %s", ins.Result, ins.Left, ins.Right)
+}
+
 // GreaterThanString will compare two strings.
 type GreaterThanString struct {
-	Left, Right, Result string
+	Left, Right, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *GreaterThanString) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *GreaterThanString) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	registers[ins.Result] = asttest.NewLiteralBool(
 		registers[ins.Left].Value > registers[ins.Right].Value,
 	)
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *GreaterThanString) String() string {
+	return fmt.Sprintf("%s = %s > %s", ins.Result, ins.Left, ins.Right)
 }

--- a/vm/greater_than_equal.go
+++ b/vm/greater_than_equal.go
@@ -1,6 +1,8 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/number"
@@ -8,11 +10,11 @@ import (
 
 // GreaterThanEqualNumber will compare two numbers.
 type GreaterThanEqualNumber struct {
-	Left, Right, Result string
+	Left, Right, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *GreaterThanEqualNumber) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *GreaterThanEqualNumber) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	registers[ins.Result] = asttest.NewLiteralBool(number.Cmp(
 		number.NewNumber(registers[ins.Left].Value),
 		number.NewNumber(registers[ins.Right].Value),
@@ -21,16 +23,26 @@ func (ins *GreaterThanEqualNumber) Execute(registers map[string]*ast.Literal, _ 
 	return nil
 }
 
+// String is the human-readable description of the instruction.
+func (ins *GreaterThanEqualNumber) String() string {
+	return fmt.Sprintf("%s = %s >= %s", ins.Result, ins.Left, ins.Right)
+}
+
 // GreaterThanEqualString will compare two strings.
 type GreaterThanEqualString struct {
-	Left, Right, Result string
+	Left, Right, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *GreaterThanEqualString) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *GreaterThanEqualString) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	registers[ins.Result] = asttest.NewLiteralBool(
 		registers[ins.Left].Value >= registers[ins.Right].Value,
 	)
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *GreaterThanEqualString) String() string {
+	return fmt.Sprintf("%s = %s >= %s", ins.Result, ins.Left, ins.Right)
 }

--- a/vm/greater_than_equal_test.go
+++ b/vm/greater_than_equal_test.go
@@ -24,7 +24,7 @@ func TestGreaterThanEqualString_Execute(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			registers := map[string]*ast.Literal{
+			registers := map[vm.Register]*ast.Literal{
 				"0": test.left,
 				"1": test.right,
 			}
@@ -49,7 +49,7 @@ func TestGreaterThanEqualNumber_Execute(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			registers := map[string]*ast.Literal{
+			registers := map[vm.Register]*ast.Literal{
 				"0": test.left,
 				"1": test.right,
 			}
@@ -58,4 +58,14 @@ func TestGreaterThanEqualNumber_Execute(t *testing.T) {
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}
+}
+
+func TestGreaterThanEqualString_String(t *testing.T) {
+	ins := &vm.GreaterThanEqualString{Left: "1", Right: "2", Result: "3"}
+	assert.Equal(t, "$3 = $1 >= $2", ins.String())
+}
+
+func TestGreaterThanEqualNumber_String(t *testing.T) {
+	ins := &vm.GreaterThanEqualNumber{Left: "1", Right: "2", Result: "3"}
+	assert.Equal(t, "$3 = $1 >= $2", ins.String())
 }

--- a/vm/greater_than_test.go
+++ b/vm/greater_than_test.go
@@ -24,7 +24,7 @@ func TestGreaterThanString_Execute(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			registers := map[string]*ast.Literal{
+			registers := map[vm.Register]*ast.Literal{
 				"0": test.left,
 				"1": test.right,
 			}
@@ -49,7 +49,7 @@ func TestGreaterThanNumber_Execute(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			registers := map[string]*ast.Literal{
+			registers := map[vm.Register]*ast.Literal{
 				"0": test.left,
 				"1": test.right,
 			}
@@ -58,4 +58,14 @@ func TestGreaterThanNumber_Execute(t *testing.T) {
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}
+}
+
+func TestGreaterThanString_String(t *testing.T) {
+	ins := &vm.GreaterThanString{Left: "1", Right: "2", Result: "3"}
+	assert.Equal(t, "$3 = $1 > $2", ins.String())
+}
+
+func TestGreaterThanNumber_String(t *testing.T) {
+	ins := &vm.GreaterThanNumber{Left: "1", Right: "2", Result: "3"}
+	assert.Equal(t, "$3 = $1 > $2", ins.String())
 }

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -1,8 +1,16 @@
 package vm
 
-import "github.com/elliotchance/ok/ast"
+import (
+	"fmt"
+
+	"github.com/elliotchance/ok/ast"
+)
 
 // An Instruction can be executed by the VM.
 type Instruction interface {
-	Execute(registers map[string]*ast.Literal, currentInstruction *int, vm *VM) error
+	// Stringer provides human-readable descriptions of instructions. It's
+	// helpful for debugging and used directly by "ok asm".
+	fmt.Stringer
+
+	Execute(registers map[Register]*ast.Literal, currentInstruction *int, vm *VM) error
 }

--- a/vm/interpolate.go
+++ b/vm/interpolate.go
@@ -12,12 +12,12 @@ import (
 
 // Interpolate combines strings and expressions into one string result.
 type Interpolate struct {
-	Result string
-	Args   []string
+	Result Register
+	Args   Registers
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Interpolate) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *Interpolate) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	s := ""
 
 	for _, arg := range ins.Args {
@@ -27,6 +27,11 @@ func (ins *Interpolate) Execute(registers map[string]*ast.Literal, _ *int, _ *VM
 	registers[ins.Result] = asttest.NewLiteralString(s)
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *Interpolate) String() string {
+	return fmt.Sprintf("%s = interpolate %s", ins.Result, ins.Args)
 }
 
 func renderLiteral(v *ast.Literal, asJSON bool) string {

--- a/vm/jump.go
+++ b/vm/jump.go
@@ -1,6 +1,8 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 )
 
@@ -10,8 +12,13 @@ type Jump struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Jump) Execute(registers map[string]*ast.Literal, i *int, _ *VM) error {
+func (ins *Jump) Execute(registers map[Register]*ast.Literal, i *int, _ *VM) error {
 	*i = ins.To
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *Jump) String() string {
+	return fmt.Sprintf("jump to #%d", ins.To)
 }

--- a/vm/jump_unless.go
+++ b/vm/jump_unless.go
@@ -1,20 +1,27 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 )
 
 // JumpUnless will jump to the instruction if the expression is false.
 type JumpUnless struct {
-	Condition string
+	Condition Register
 	To        int
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *JumpUnless) Execute(registers map[string]*ast.Literal, i *int, _ *VM) error {
+func (ins *JumpUnless) Execute(registers map[Register]*ast.Literal, i *int, _ *VM) error {
 	if registers[ins.Condition].Value != "true" {
 		*i = ins.To
 	}
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *JumpUnless) String() string {
+	return fmt.Sprintf("if %s is false then jump to #%d", ins.Condition, ins.To)
 }

--- a/vm/len.go
+++ b/vm/len.go
@@ -10,11 +10,11 @@ import (
 
 // Len is used to determine the size of an array or map.
 type Len struct {
-	Argument, Result string
+	Argument, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Len) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *Len) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	r := registers[ins.Argument]
 	var result int
 	switch {
@@ -34,4 +34,9 @@ func (ins *Len) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error 
 	registers[ins.Result] = asttest.NewLiteralNumber(fmt.Sprintf("%d", result))
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *Len) String() string {
+	return fmt.Sprintf("%s = len(%s)", ins.Result, ins.Argument)
 }

--- a/vm/len_test.go
+++ b/vm/len_test.go
@@ -22,7 +22,7 @@ func TestLen_Execute(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			registers := map[string]*ast.Literal{
+			registers := map[vm.Register]*ast.Literal{
 				"0": test.x,
 			}
 			ins := &vm.Len{Argument: "0", Result: "1"}

--- a/vm/less_than.go
+++ b/vm/less_than.go
@@ -1,6 +1,8 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/number"
@@ -8,11 +10,11 @@ import (
 
 // LessThanNumber will compare two numbers.
 type LessThanNumber struct {
-	Left, Right, Result string
+	Left, Right, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *LessThanNumber) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *LessThanNumber) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	registers[ins.Result] = asttest.NewLiteralBool(number.Cmp(
 		number.NewNumber(registers[ins.Left].Value),
 		number.NewNumber(registers[ins.Right].Value),
@@ -21,16 +23,26 @@ func (ins *LessThanNumber) Execute(registers map[string]*ast.Literal, _ *int, _ 
 	return nil
 }
 
+// String is the human-readable description of the instruction.
+func (ins *LessThanNumber) String() string {
+	return fmt.Sprintf("%s = %s < %s", ins.Result, ins.Left, ins.Right)
+}
+
 // LessThanString will compare two strings.
 type LessThanString struct {
-	Left, Right, Result string
+	Left, Right, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *LessThanString) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *LessThanString) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	registers[ins.Result] = asttest.NewLiteralBool(
 		registers[ins.Left].Value < registers[ins.Right].Value,
 	)
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *LessThanString) String() string {
+	return fmt.Sprintf("%s = %s < %s", ins.Result, ins.Left, ins.Right)
 }

--- a/vm/less_than_equal.go
+++ b/vm/less_than_equal.go
@@ -1,6 +1,8 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/number"
@@ -8,11 +10,11 @@ import (
 
 // LessThanEqualNumber will compare two numbers.
 type LessThanEqualNumber struct {
-	Left, Right, Result string
+	Left, Right, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *LessThanEqualNumber) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *LessThanEqualNumber) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	registers[ins.Result] = asttest.NewLiteralBool(number.Cmp(
 		number.NewNumber(registers[ins.Left].Value),
 		number.NewNumber(registers[ins.Right].Value),
@@ -21,16 +23,26 @@ func (ins *LessThanEqualNumber) Execute(registers map[string]*ast.Literal, _ *in
 	return nil
 }
 
+// String is the human-readable description of the instruction.
+func (ins *LessThanEqualNumber) String() string {
+	return fmt.Sprintf("%s = %s <= %s", ins.Result, ins.Left, ins.Right)
+}
+
 // LessThanEqualString will compare two strings.
 type LessThanEqualString struct {
-	Left, Right, Result string
+	Left, Right, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *LessThanEqualString) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *LessThanEqualString) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	registers[ins.Result] = asttest.NewLiteralBool(
 		registers[ins.Left].Value <= registers[ins.Right].Value,
 	)
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *LessThanEqualString) String() string {
+	return fmt.Sprintf("%s = %s <= %s", ins.Result, ins.Left, ins.Right)
 }

--- a/vm/less_than_equal_test.go
+++ b/vm/less_than_equal_test.go
@@ -24,7 +24,7 @@ func TestLessThanEqualString_Execute(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			registers := map[string]*ast.Literal{
+			registers := map[vm.Register]*ast.Literal{
 				"0": test.left,
 				"1": test.right,
 			}
@@ -49,7 +49,7 @@ func TestLessThanEqualNumber_Execute(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			registers := map[string]*ast.Literal{
+			registers := map[vm.Register]*ast.Literal{
 				"0": test.left,
 				"1": test.right,
 			}
@@ -58,4 +58,14 @@ func TestLessThanEqualNumber_Execute(t *testing.T) {
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}
+}
+
+func TestLessThanEqualString_String(t *testing.T) {
+	ins := &vm.LessThanEqualString{Left: "1", Right: "2", Result: "3"}
+	assert.Equal(t, "$3 = $1 <= $2", ins.String())
+}
+
+func TestLessThanEqualNumber_String(t *testing.T) {
+	ins := &vm.LessThanEqualNumber{Left: "1", Right: "2", Result: "3"}
+	assert.Equal(t, "$3 = $1 <= $2", ins.String())
 }

--- a/vm/less_than_test.go
+++ b/vm/less_than_test.go
@@ -24,7 +24,7 @@ func TestLessThanString_Execute(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			registers := map[string]*ast.Literal{
+			registers := map[vm.Register]*ast.Literal{
 				"0": test.left,
 				"1": test.right,
 			}
@@ -49,7 +49,7 @@ func TestLessThanNumber_Execute(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			registers := map[string]*ast.Literal{
+			registers := map[vm.Register]*ast.Literal{
 				"0": test.left,
 				"1": test.right,
 			}
@@ -58,4 +58,14 @@ func TestLessThanNumber_Execute(t *testing.T) {
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}
+}
+
+func TestLessThanString_String(t *testing.T) {
+	ins := &vm.LessThanString{Left: "1", Right: "2", Result: "3"}
+	assert.Equal(t, "$3 = $1 < $2", ins.String())
+}
+
+func TestLessThanNumber_String(t *testing.T) {
+	ins := &vm.LessThanNumber{Left: "1", Right: "2", Result: "3"}
+	assert.Equal(t, "$3 = $1 < $2", ins.String())
 }

--- a/vm/log.go
+++ b/vm/log.go
@@ -1,6 +1,8 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/number"
@@ -8,11 +10,11 @@ import (
 
 // Log is a natural logarithm (base e).
 type Log struct {
-	X, Result string
+	X, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Log) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *Log) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	registers[ins.Result] = asttest.NewLiteralNumber(
 		number.Log(
 			number.NewNumber(registers[ins.X].Value),
@@ -20,4 +22,9 @@ func (ins *Log) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error 
 	)
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *Log) String() string {
+	return fmt.Sprintf("%s = log(%s)", ins.Result, ins.X)
 }

--- a/vm/map_alloc.go
+++ b/vm/map_alloc.go
@@ -1,17 +1,19 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/number"
 )
 
 // MapAllocNumber allocates a "{}number" of fixed size.
 type MapAllocNumber struct {
-	Size, Result string
+	Size, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *MapAllocNumber) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *MapAllocNumber) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	size := number.Int64(number.NewNumber(registers[ins.Size].Value))
 
 	registers[ins.Result] = &ast.Literal{
@@ -25,4 +27,9 @@ func (ins *MapAllocNumber) Execute(registers map[string]*ast.Literal, _ *int, _ 
 	}
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *MapAllocNumber) String() string {
+	return fmt.Sprintf("%s = {}number with %s elements", ins.Result, ins.Size)
 }

--- a/vm/map_get.go
+++ b/vm/map_get.go
@@ -1,18 +1,25 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 )
 
 // MapGet gets a value from the map by its key.
 type MapGet struct {
-	Map, Key, Result string
+	Map, Key, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *MapGet) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *MapGet) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	key := registers[ins.Key].Value
 	registers[ins.Result] = registers[ins.Map].Map[key]
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *MapGet) String() string {
+	return fmt.Sprintf("%s = %s[%s]", ins.Result, ins.Map, ins.Key)
 }

--- a/vm/map_set.go
+++ b/vm/map_set.go
@@ -1,19 +1,26 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 )
 
 // MapSet sets a number value to an index.
 type MapSet struct {
-	Map, Key, Value string
+	Map, Key, Value Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *MapSet) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *MapSet) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	key := registers[ins.Key].Value
 	registers[ins.Map].Map[key] = registers[ins.Value]
 	registers[ins.Map].Array = append(registers[ins.Map].Array, registers[ins.Key])
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *MapSet) String() string {
+	return fmt.Sprintf("%s[%s] = %s", ins.Map, ins.Key, ins.Value)
 }

--- a/vm/multiply.go
+++ b/vm/multiply.go
@@ -1,6 +1,8 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/number"
@@ -8,11 +10,11 @@ import (
 
 // Multiply will multiply two numbers.
 type Multiply struct {
-	Left, Right, Result string
+	Left, Right, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Multiply) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *Multiply) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	registers[ins.Result] = asttest.NewLiteralNumber(
 		number.Multiply(
 			number.NewNumber(registers[ins.Left].Value),
@@ -21,4 +23,9 @@ func (ins *Multiply) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) e
 	)
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *Multiply) String() string {
+	return fmt.Sprintf("%s = %s * %s", ins.Result, ins.Left, ins.Right)
 }

--- a/vm/multiply_test.go
+++ b/vm/multiply_test.go
@@ -19,7 +19,7 @@ func TestMultiply_Execute(t *testing.T) {
 		"success": {"1.2200", "4.7", "5.734"},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			registers := map[string]*ast.Literal{
+			registers := map[vm.Register]*ast.Literal{
 				"0": asttest.NewLiteralNumber(test.left),
 				"1": asttest.NewLiteralNumber(test.right),
 			}

--- a/vm/next_array.go
+++ b/vm/next_array.go
@@ -10,15 +10,15 @@ import (
 
 // NextArray is used to tick an array iterator forward.
 type NextArray struct {
-	Array       string // Register In (array): Containing the iterating array.
-	Cursor      string // Register In (number): Containing the current position.
-	KeyResult   string // Register Out (any): Load the key into this register.
-	ValueResult string // Register Out (any): Load the value into this register.
-	Result      string // Register Out (bool): Still more items?
+	Array       Register // In (array): Containing the iterating array.
+	Cursor      Register // In (number): Containing the current position.
+	KeyResult   Register // Out (any): Load the key into this register.
+	ValueResult Register // Out (any): Load the value into this register.
+	Result      Register // Out (bool): Still more items?
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *NextArray) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *NextArray) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	array := registers[ins.Array].Array
 	pos := number.Int(number.NewNumber(registers[ins.Cursor].Value))
 	hasMore := pos < len(array)
@@ -30,4 +30,10 @@ func (ins *NextArray) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) 
 	}
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *NextArray) String() string {
+	return fmt.Sprintf("%s, %s = next from %s; increment %s; has more %s",
+		ins.ValueResult, ins.KeyResult, ins.Array, ins.Cursor, ins.Result)
 }

--- a/vm/next_map.go
+++ b/vm/next_map.go
@@ -10,15 +10,15 @@ import (
 
 // NextMap is used to tick a map iterator forward.
 type NextMap struct {
-	Map         string // Register In (map): Containing the iterating map.
-	Cursor      string // Register In (number): Containing the current position.
-	KeyResult   string // Register Out (any): Load the key into this register.
-	ValueResult string // Register Out (any): Load the value into this register.
-	Result      string // Register Out (bool): Still more items?
+	Map         Register // In (map): Containing the iterating map.
+	Cursor      Register // In (number): Containing the current position.
+	KeyResult   Register // Out (any): Load the key into this register.
+	ValueResult Register // Out (any): Load the value into this register.
+	Result      Register // Out (bool): Still more items?
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *NextMap) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *NextMap) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	array := registers[ins.Map].Array
 	pos := number.Int(number.NewNumber(registers[ins.Cursor].Value))
 
@@ -32,4 +32,10 @@ func (ins *NextMap) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) er
 	}
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *NextMap) String() string {
+	return fmt.Sprintf("%s, %s = next from %s; increment %s; has more %s",
+		ins.ValueResult, ins.KeyResult, ins.Map, ins.Cursor, ins.Result)
 }

--- a/vm/next_string.go
+++ b/vm/next_string.go
@@ -10,16 +10,16 @@ import (
 
 // NextString is used to tick a string iterator forward.
 type NextString struct {
-	String      string // Register In (string): Containing the iterating string.
-	Cursor      string // Register In (number): Containing the current position.
-	KeyResult   string // Register Out (any): Load the key into this register.
-	ValueResult string // Register Out (any): Load the value into this register.
-	Result      string // Register Out (bool): Still more items?
+	Str         Register // In (string): Containing the iterating string.
+	Cursor      Register // In (number): Containing the current position.
+	KeyResult   Register // Out (any): Load the key into this register.
+	ValueResult Register // Out (any): Load the value into this register.
+	Result      Register // Out (bool): Still more items?
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *NextString) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
-	str := []rune(registers[ins.String].Value)
+func (ins *NextString) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
+	str := []rune(registers[ins.Str].Value)
 	pos := number.Int(number.NewNumber(registers[ins.Cursor].Value))
 	hasMore := pos < len(str)
 	registers[ins.Result] = asttest.NewLiteralBool(hasMore)
@@ -30,4 +30,10 @@ func (ins *NextString) Execute(registers map[string]*ast.Literal, _ *int, _ *VM)
 	}
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *NextString) String() string {
+	return fmt.Sprintf("%s, %s = next from %s; increment %s; has more %s",
+		ins.ValueResult, ins.KeyResult, ins.Str, ins.Cursor, ins.Result)
 }

--- a/vm/not.go
+++ b/vm/not.go
@@ -1,20 +1,27 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 )
 
 // Not is a logical NOT of a bool.
 type Not struct {
-	Left, Result string
+	Left, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Not) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *Not) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	registers[ins.Result] = asttest.NewLiteralBool(
 		!(registers[ins.Left].Value == "true"),
 	)
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *Not) String() string {
+	return fmt.Sprintf("%s = not %s", ins.Result, ins.Left)
 }

--- a/vm/not_equal.go
+++ b/vm/not_equal.go
@@ -1,17 +1,19 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 )
 
 // NotEqualNumber will compare two numbers for equality.
 type NotEqualNumber struct {
-	Left, Right, Result string
+	Left, Right, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *NotEqualNumber) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *NotEqualNumber) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	registers[ins.Result] = asttest.NewLiteralBool(!numbersAreEqual(
 		registers[ins.Left],
 		registers[ins.Right],
@@ -20,19 +22,29 @@ func (ins *NotEqualNumber) Execute(registers map[string]*ast.Literal, _ *int, _ 
 	return nil
 }
 
+// String is the human-readable description of the instruction.
+func (ins *NotEqualNumber) String() string {
+	return fmt.Sprintf("%s = %s != %s", ins.Result, ins.Left, ins.Right)
+}
+
 // NotEqual will compare two non-numbers for non-equality. This works for every
 // other type because every other type is stored as a string. When optimizations
 // are made in the future this will need to be expanded to one instruction per
 // type.
 type NotEqual struct {
-	Left, Right, Result string
+	Left, Right, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *NotEqual) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *NotEqual) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	registers[ins.Result] = asttest.NewLiteralBool(!compareValue(
 		registers[ins.Left], registers[ins.Right],
 	))
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *NotEqual) String() string {
+	return fmt.Sprintf("%s = %s != %s", ins.Result, ins.Left, ins.Right)
 }

--- a/vm/not_equal_test.go
+++ b/vm/not_equal_test.go
@@ -45,7 +45,7 @@ func TestNotEqual_Execute(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			registers := map[string]*ast.Literal{
+			registers := map[vm.Register]*ast.Literal{
 				"0": test.left,
 				"1": test.right,
 			}
@@ -70,7 +70,7 @@ func TestNotEqualNumber_Execute(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			registers := map[string]*ast.Literal{
+			registers := map[vm.Register]*ast.Literal{
 				"0": test.left,
 				"1": test.right,
 			}
@@ -79,4 +79,14 @@ func TestNotEqualNumber_Execute(t *testing.T) {
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}
+}
+
+func TestNotEqual_String(t *testing.T) {
+	ins := &vm.NotEqual{Left: "1", Right: "2", Result: "3"}
+	assert.Equal(t, "$3 = $1 != $2", ins.String())
+}
+
+func TestNotEqualNumber_String(t *testing.T) {
+	ins := &vm.NotEqualNumber{Left: "1", Right: "2", Result: "3"}
+	assert.Equal(t, "$3 = $1 != $2", ins.String())
 }

--- a/vm/not_test.go
+++ b/vm/not_test.go
@@ -19,7 +19,7 @@ func TestNot_Execute(t *testing.T) {
 		"true":  {true, "false"},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			registers := map[string]*ast.Literal{
+			registers := map[vm.Register]*ast.Literal{
 				"0": asttest.NewLiteralBool(test.left),
 			}
 			ins := &vm.Not{Left: "0", Result: "1"}

--- a/vm/or.go
+++ b/vm/or.go
@@ -1,21 +1,28 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 )
 
 // Or is a logical OR between two bools.
 type Or struct {
-	Left, Right, Result string
+	Left, Right, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Or) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *Or) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	registers[ins.Result] = asttest.NewLiteralBool(
 		(registers[ins.Left].Value == "true") ||
 			(registers[ins.Right].Value == "true"),
 	)
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *Or) String() string {
+	return fmt.Sprintf("%s = %s or %s", ins.Result, ins.Left, ins.Right)
 }

--- a/vm/or_test.go
+++ b/vm/or_test.go
@@ -21,7 +21,7 @@ func TestOr_Execute(t *testing.T) {
 		"true-true":   {true, true, "true"},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			registers := map[string]*ast.Literal{
+			registers := map[vm.Register]*ast.Literal{
 				"0": asttest.NewLiteralBool(test.left),
 				"1": asttest.NewLiteralBool(test.right),
 			}

--- a/vm/power.go
+++ b/vm/power.go
@@ -1,6 +1,8 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/number"
@@ -8,11 +10,11 @@ import (
 
 // Power is Left to the power of Right.
 type Power struct {
-	Base, Power, Result string
+	Base, Power, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Power) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *Power) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	registers[ins.Result] = asttest.NewLiteralNumber(
 		number.Pow(
 			number.NewNumber(registers[ins.Base].Value),
@@ -21,4 +23,9 @@ func (ins *Power) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) erro
 	)
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *Power) String() string {
+	return fmt.Sprintf("%s = power(%s, %s)", ins.Result, ins.Base, ins.Power)
 }

--- a/vm/print.go
+++ b/vm/print.go
@@ -8,11 +8,11 @@ import (
 
 // Print will output a string to stdout.
 type Print struct {
-	Arguments []string
+	Arguments Registers
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Print) Execute(registers map[string]*ast.Literal, _ *int, vm *VM) error {
+func (ins *Print) Execute(registers map[Register]*ast.Literal, _ *int, vm *VM) error {
 	for i, register := range ins.Arguments {
 		if i > 0 {
 			fmt.Fprint(vm.Stdout, " ")
@@ -24,4 +24,9 @@ func (ins *Print) Execute(registers map[string]*ast.Literal, _ *int, vm *VM) err
 	fmt.Fprint(vm.Stdout, "\n")
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *Print) String() string {
+	return fmt.Sprintf("print%s", ins.Arguments)
 }

--- a/vm/print_test.go
+++ b/vm/print_test.go
@@ -118,10 +118,10 @@ func TestPrint_Execute(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			registers := map[string]*ast.Literal{}
-			var arguments []string
+			registers := map[vm.Register]*ast.Literal{}
+			var arguments []vm.Register
 			for i, value := range test.values {
-				register := fmt.Sprintf("%d", i)
+				register := vm.Register(fmt.Sprintf("%d", i))
 				registers[register] = value
 				arguments = append(arguments, register)
 			}

--- a/vm/raise.go
+++ b/vm/raise.go
@@ -1,22 +1,29 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 )
 
 // Raise put the VM into an error mode. The VM will look for an error handler.
 type Raise struct {
 	// Err is the register containing the error.
-	Err string
+	Err Register
 
 	// Type is used to match the handler.
 	Type string
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Raise) Execute(registers map[string]*ast.Literal, _ *int, vm *VM) error {
+func (ins *Raise) Execute(registers map[Register]*ast.Literal, _ *int, vm *VM) error {
 	vm.ErrType = ins.Type
 	vm.ErrValue = registers[ins.Err]
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *Raise) String() string {
+	return fmt.Sprintf("%s = raise %s", ins.Err, ins.Type)
 }

--- a/vm/register.go
+++ b/vm/register.go
@@ -1,0 +1,43 @@
+package vm
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// Register is the name of a register. At the moment variable names can also be
+// used as registers, but that will be removed in the future. When that happens
+// these can be refactored into an int.
+type Register string
+
+// String returns either "rX" or the name of the variable. See Register for
+// details.
+func (r Register) String() string {
+	// An empty register is sometimes used when there is no register need, like
+	// how Key is optional in NextArray.
+	if r == "" {
+		return "_"
+	}
+
+	if unicode.IsDigit([]rune(r)[0]) {
+		return "$" + string(r)
+	}
+
+	return string(r)
+}
+
+// Registers is multiple sequential registers. It might represents function
+// arguments, for example.
+type Registers []Register
+
+// String returns the registers as a set, like "(r0, r1)". The values will be
+// wrapped with parenthesis even if there are one or zero elements.
+func (rs Registers) String() string {
+	ss := make([]string, len(rs))
+	for i, r := range rs {
+		ss[i] = r.String()
+	}
+
+	return fmt.Sprintf("(%s)", strings.Join(ss, ", "))
+}

--- a/vm/register_test.go
+++ b/vm/register_test.go
@@ -1,0 +1,40 @@
+package vm_test
+
+import (
+	"testing"
+
+	"github.com/elliotchance/ok/vm"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegister_String(t *testing.T) {
+	t.Run("zero", func(t *testing.T) {
+		assert.Equal(t, "()", vm.Registers{}.String())
+	})
+
+	t.Run("one", func(t *testing.T) {
+		assert.Equal(t, "($1)", vm.Registers{"1"}.String())
+	})
+
+	t.Run("two", func(t *testing.T) {
+		assert.Equal(t, "($123, a7)", vm.Registers{"123", "a7"}.String())
+	})
+}
+
+func TestRegisters_String(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		assert.Equal(t, "_", vm.Register("").String())
+	})
+
+	t.Run("register", func(t *testing.T) {
+		assert.Equal(t, "$0", vm.Register("0").String())
+		assert.Equal(t, "$123", vm.Register("123").String())
+	})
+
+	// TODO(elliot): Using variable names as registers will be removed in the
+	//  future.
+	t.Run("variable-name", func(t *testing.T) {
+		assert.Equal(t, "foo", vm.Register("foo").String())
+		assert.Equal(t, "r1", vm.Register("r1").String())
+	})
+}

--- a/vm/remainder.go
+++ b/vm/remainder.go
@@ -1,6 +1,8 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/number"
@@ -9,11 +11,11 @@ import (
 // Remainder will return the remainder when dividing two numbers. This is not
 // the same as a modulo. A remainder may be negative.
 type Remainder struct {
-	Left, Right, Result string
+	Left, Right, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Remainder) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *Remainder) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	divide, err := number.Remainder(
 		number.NewNumber(registers[ins.Left].Value),
 		number.NewNumber(registers[ins.Right].Value),
@@ -26,4 +28,9 @@ func (ins *Remainder) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) 
 
 	registers[ins.Result] = asttest.NewLiteralNumber(divide.String())
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *Remainder) String() string {
+	return fmt.Sprintf("%s = %s %% %s", ins.Result, ins.Left, ins.Right)
 }

--- a/vm/remainder_test.go
+++ b/vm/remainder_test.go
@@ -21,7 +21,7 @@ func TestRemainder_Execute(t *testing.T) {
 		"divide-zero":        {"1.2200", "0", "0", errors.New("division by zero")},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			registers := map[string]*ast.Literal{
+			registers := map[vm.Register]*ast.Literal{
 				"0": asttest.NewLiteralNumber(test.left),
 				"1": asttest.NewLiteralNumber(test.right),
 			}

--- a/vm/return.go
+++ b/vm/return.go
@@ -1,17 +1,24 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 )
 
 // Return tells the VM to jump out of this function.
 type Return struct {
-	Results []string
+	Results Registers
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Return) Execute(registers map[string]*ast.Literal, _ *int, vm *VM) error {
+func (ins *Return) Execute(registers map[Register]*ast.Literal, _ *int, vm *VM) error {
 	vm.Return = ins.Results
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *Return) String() string {
+	return fmt.Sprintf("return %s", ins.Results)
 }

--- a/vm/string_index.go
+++ b/vm/string_index.go
@@ -1,6 +1,8 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/number"
@@ -8,15 +10,20 @@ import (
 
 // StringIndex returns a character from an index of a string.
 type StringIndex struct {
-	String, Index, Result string
+	Str, Index, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *StringIndex) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *StringIndex) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	index := number.Int64(number.NewNumber(registers[ins.Index].Value))
 
 	// TODO(elliot): This won't work with multibyte characters.
-	registers[ins.Result] = asttest.NewLiteralChar([]rune(registers[ins.String].Value)[index])
+	registers[ins.Result] = asttest.NewLiteralChar([]rune(registers[ins.Str].Value)[index])
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *StringIndex) String() string {
+	return fmt.Sprintf("%s = %s[%s]", ins.Result, ins.Str, ins.Index)
 }

--- a/vm/subtract.go
+++ b/vm/subtract.go
@@ -1,6 +1,8 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/number"
@@ -8,11 +10,11 @@ import (
 
 // Subtract will subtract two numbers.
 type Subtract struct {
-	Left, Right, Result string
+	Left, Right, Result Register
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Subtract) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) error {
+func (ins *Subtract) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
 	registers[ins.Result] = asttest.NewLiteralNumber(
 		number.Subtract(
 			number.NewNumber(registers[ins.Left].Value),
@@ -21,4 +23,9 @@ func (ins *Subtract) Execute(registers map[string]*ast.Literal, _ *int, _ *VM) e
 	)
 
 	return nil
+}
+
+// String is the human-readable description of the instruction.
+func (ins *Subtract) String() string {
+	return fmt.Sprintf("%s = %s - %s", ins.Result, ins.Left, ins.Right)
 }

--- a/vm/subtract_test.go
+++ b/vm/subtract_test.go
@@ -18,7 +18,7 @@ func TestSubtract_Execute(t *testing.T) {
 		"maintain-precision": {"1.2200", "4.7", "-3.4800"},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			registers := map[string]*ast.Literal{
+			registers := map[vm.Register]*ast.Literal{
 				"0": asttest.NewLiteralNumber(test.left),
 				"1": asttest.NewLiteralNumber(test.right),
 			}
@@ -27,4 +27,9 @@ func TestSubtract_Execute(t *testing.T) {
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}
+}
+
+func TestSubtract_String(t *testing.T) {
+	ins := &vm.Subtract{Left: "1", Right: "2", Result: "3"}
+	assert.Equal(t, "$3 = $1 - $2", ins.String())
 }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -28,8 +28,8 @@ type CompiledTest struct {
 // VM is an instance of a virtual machine to run ok instructions.
 type VM struct {
 	fns    map[string]*CompiledFunc
-	Return []string
-	stack  []map[string]*ast.Literal
+	Return []Register
+	stack  []map[Register]*ast.Literal
 	tests  []*CompiledTest
 	pkg    string
 	Stdout io.Writer
@@ -85,10 +85,10 @@ func (vm *VM) RunTests() error {
 	return nil
 }
 
-func (vm *VM) call(name string, arguments []string) ([]string, error) {
+func (vm *VM) call(name string, arguments []Register) ([]Register, error) {
 	// TODO(elliot): Check function exists, especially main.
 
-	registers := map[string]*ast.Literal{}
+	registers := map[Register]*ast.Literal{}
 
 	// Copy the registers of this context into the new call context.
 	fn := vm.fns[name]
@@ -111,7 +111,7 @@ func (vm *VM) call(name string, arguments []string) ([]string, error) {
 	vm.FinallyBlocks = append(vm.FinallyBlocks, finallyBlocks)
 
 	for i, arg := range arguments {
-		registers[fn.Arguments[i]] = vm.stack[len(vm.stack)-1][arg]
+		registers[Register(fn.Arguments[i])] = vm.stack[len(vm.stack)-1][arg]
 	}
 	vm.stack = append(vm.stack, registers)
 
@@ -137,7 +137,7 @@ func (vm *VM) call(name string, arguments []string) ([]string, error) {
 	return returns, nil
 }
 
-func (vm *VM) runInstructions(ins []Instruction, registers map[string]*ast.Literal, inFinally bool) ([]string, error) {
+func (vm *VM) runInstructions(ins []Instruction, registers map[Register]*ast.Literal, inFinally bool) ([]Register, error) {
 	totalInstructions := len(ins)
 	for i := 0; i < totalInstructions; i++ {
 		ins := ins[i]
@@ -191,7 +191,7 @@ func (vm *VM) runInstructions(ins []Instruction, registers map[string]*ast.Liter
 func (vm *VM) runTest(testName string, instructions []Instruction) error {
 	vm.CurrentTestName = testName
 
-	registers := map[string]*ast.Literal{}
+	registers := map[Register]*ast.Literal{}
 	vm.stack = append(vm.stack, registers)
 
 	totalInstructions := len(instructions)


### PR DESCRIPTION
The `asm` tool is useful for debugging. It will print out human-readable
descriptions of each of the compiled instructions for one or more
functions. Usage:

    ok asm package-name function1 function2 ...

Without providing any arguments it will use the current package and
output the `main` function, this is equivalent to running:

    ok asm . main

Here is the output from the `hello-world` example:

    func main():
        1 Assign                 # $1 = "Hello, World!"
        2 Print                  # print($1)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/ok/50)
<!-- Reviewable:end -->
