### PR TITLE
Moving all registers into the VM

### DIFF
--- a/vm/add.go
+++ b/vm/add.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"fmt"
 
-	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/number"
 )
@@ -14,13 +13,13 @@ type Add struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Add) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	registers[ins.Result] = asttest.NewLiteralNumber(
+func (ins *Add) Execute(_ *int, vm *VM) error {
+	vm.Set(ins.Result, asttest.NewLiteralNumber(
 		number.Add(
-			number.NewNumber(registers[ins.Left].Value),
-			number.NewNumber(registers[ins.Right].Value),
+			number.NewNumber(vm.Get(ins.Left).Value),
+			number.NewNumber(vm.Get(ins.Right).Value),
 		).String(),
-	)
+	))
 
 	return nil
 }

--- a/vm/add_test.go
+++ b/vm/add_test.go
@@ -23,7 +23,10 @@ func TestAdd_Execute(t *testing.T) {
 				"1": asttest.NewLiteralNumber(test.right),
 			}
 			ins := &vm.Add{Left: "0", Right: "1", Result: "2"}
-			assert.NoError(t, ins.Execute(registers, nil, nil))
+			vm := &vm.VM{
+				Stack: []map[vm.Register]*ast.Literal{registers},
+			}
+			assert.NoError(t, ins.Execute(nil, vm))
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}

--- a/vm/and.go
+++ b/vm/and.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"fmt"
 
-	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 )
 
@@ -13,11 +12,11 @@ type And struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *And) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	registers[ins.Result] = asttest.NewLiteralBool(
-		(registers[ins.Left].Value == "true") &&
-			(registers[ins.Right].Value == "true"),
-	)
+func (ins *And) Execute(_ *int, vm *VM) error {
+	vm.Set(ins.Result, asttest.NewLiteralBool(
+		(vm.Get(ins.Left).Value == "true") &&
+			(vm.Get(ins.Right).Value == "true"),
+	))
 
 	return nil
 }

--- a/vm/and_test.go
+++ b/vm/and_test.go
@@ -26,7 +26,10 @@ func TestAnd_Execute(t *testing.T) {
 				"1": asttest.NewLiteralBool(test.right),
 			}
 			ins := &vm.And{Left: "0", Right: "1", Result: "2"}
-			assert.NoError(t, ins.Execute(registers, nil, nil))
+			vm := &vm.VM{
+				Stack: []map[vm.Register]*ast.Literal{registers},
+			}
+			assert.NoError(t, ins.Execute(nil, vm))
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}

--- a/vm/append.go
+++ b/vm/append.go
@@ -12,11 +12,11 @@ type Append struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Append) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	registers[ins.Result] = &ast.Literal{
-		Kind:  registers[ins.A].Kind,
-		Array: append(registers[ins.A].Array, registers[ins.B].Array...),
-	}
+func (ins *Append) Execute(_ *int, vm *VM) error {
+	vm.Set(ins.Result, &ast.Literal{
+		Kind:  vm.Get(ins.A).Kind,
+		Array: append(vm.Get(ins.A).Array, vm.Get(ins.B).Array...),
+	})
 
 	return nil
 }

--- a/vm/array_alloc.go
+++ b/vm/array_alloc.go
@@ -14,13 +14,13 @@ type ArrayAlloc struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *ArrayAlloc) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	size := number.Int64(number.NewNumber(registers[ins.Size].Value))
+func (ins *ArrayAlloc) Execute(_ *int, vm *VM) error {
+	size := number.Int64(number.NewNumber(vm.Get(ins.Size).Value))
 
-	registers[ins.Result] = &ast.Literal{
+	vm.Set(ins.Result, &ast.Literal{
 		Kind:  ins.Kind,
 		Array: make([]*ast.Literal, size),
-	}
+	})
 
 	return nil
 }

--- a/vm/array_get.go
+++ b/vm/array_get.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"fmt"
 
-	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/number"
 )
 
@@ -13,9 +12,9 @@ type ArrayGet struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *ArrayGet) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	index := number.Int64(number.NewNumber(registers[ins.Index].Value))
-	registers[ins.Result] = registers[ins.Array].Array[index]
+func (ins *ArrayGet) Execute(_ *int, vm *VM) error {
+	index := number.Int64(number.NewNumber(vm.Get(ins.Index).Value))
+	vm.Set(ins.Result, vm.Get(ins.Array).Array[index])
 
 	return nil
 }

--- a/vm/array_set.go
+++ b/vm/array_set.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"fmt"
 
-	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/number"
 )
 
@@ -13,9 +12,9 @@ type ArraySet struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *ArraySet) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	index := number.Int64(number.NewNumber(registers[ins.Index].Value))
-	registers[ins.Array].Array[index] = registers[ins.Value]
+func (ins *ArraySet) Execute(_ *int, vm *VM) error {
+	index := number.Int64(number.NewNumber(vm.Get(ins.Index).Value))
+	vm.Get(ins.Array).Array[index] = vm.Get(ins.Value)
 
 	return nil
 }

--- a/vm/assert.go
+++ b/vm/assert.go
@@ -2,8 +2,6 @@ package vm
 
 import (
 	"fmt"
-
-	"github.com/elliotchance/ok/ast"
 )
 
 // Assert is used in tests.
@@ -14,10 +12,10 @@ type Assert struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Assert) Execute(registers map[Register]*ast.Literal, _ *int, vm *VM) error {
-	pass := registers[ins.Final].Value == "true"
-	left := renderLiteral(registers[ins.Left], true)
-	right := renderLiteral(registers[ins.Right], true)
+func (ins *Assert) Execute(_ *int, vm *VM) error {
+	pass := vm.Get(ins.Final).Value == "true"
+	left := renderLiteral(vm.Get(ins.Left), true)
+	right := renderLiteral(vm.Get(ins.Right), true)
 	vm.assert(pass, left, ins.Op, right, ins.Pos)
 
 	return nil

--- a/vm/assign.go
+++ b/vm/assign.go
@@ -14,11 +14,11 @@ type Assign struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Assign) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
+func (ins *Assign) Execute(_ *int, vm *VM) error {
 	if ins.Value != nil {
-		registers[ins.VariableName] = ins.Value
+		vm.Set(ins.VariableName, ins.Value)
 	} else {
-		registers[ins.VariableName] = registers[ins.Register]
+		vm.Set(ins.VariableName, vm.Get(ins.Register))
 	}
 
 	return nil

--- a/vm/assign_test.go
+++ b/vm/assign_test.go
@@ -14,7 +14,10 @@ func TestAssign_Execute(t *testing.T) {
 	t.Run("literal", func(t *testing.T) {
 		registers := map[vm.Register]*ast.Literal{}
 		ins := &vm.Assign{VariableName: "1", Value: asttest.NewLiteralNumber("1.5")}
-		assert.NoError(t, ins.Execute(registers, nil, nil))
+		vm := &vm.VM{
+			Stack: []map[vm.Register]*ast.Literal{registers},
+		}
+		assert.NoError(t, ins.Execute(nil, vm))
 		assert.Equal(t, "1.5", registers["1"].Value)
 	})
 
@@ -23,7 +26,10 @@ func TestAssign_Execute(t *testing.T) {
 			"0": asttest.NewLiteralNumber("1.5"),
 		}
 		ins := &vm.Assign{VariableName: "1", Register: "0"}
-		assert.NoError(t, ins.Execute(registers, nil, nil))
+		vm := &vm.VM{
+			Stack: []map[vm.Register]*ast.Literal{registers},
+		}
+		assert.NoError(t, ins.Execute(nil, vm))
 		assert.Equal(t, "1.5", registers["1"].Value)
 	})
 }

--- a/vm/call.go
+++ b/vm/call.go
@@ -2,8 +2,6 @@ package vm
 
 import (
 	"fmt"
-
-	"github.com/elliotchance/ok/ast"
 )
 
 // Call tells the VM to jump to another function.
@@ -14,17 +12,17 @@ type Call struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Call) Execute(registers map[Register]*ast.Literal, i *int, vm *VM) error {
+func (ins *Call) Execute(_ *int, vm *VM) error {
 	results, err := vm.call(ins.FunctionName, ins.Arguments)
 	if err != nil {
 		return err
 	}
 
 	for i, result := range results {
-		vm.stack[len(vm.stack)-2][ins.Results[i]] = vm.stack[len(vm.stack)-1][result]
+		vm.Stack[len(vm.Stack)-2][ins.Results[i]] = vm.Stack[len(vm.Stack)-1][result]
 	}
 
-	vm.stack = vm.stack[:len(vm.stack)-1]
+	vm.Stack = vm.Stack[:len(vm.Stack)-1]
 
 	// We cannot rollback the FinallyBlocks stack here because we may need to
 	// run some of them as part of the return. They will be removed in the

--- a/vm/cast.go
+++ b/vm/cast.go
@@ -13,11 +13,11 @@ type CastString struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *CastString) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	registers[ins.Result] = &ast.Literal{
+func (ins *CastString) Execute(_ *int, vm *VM) error {
+	vm.Set(ins.Result, &ast.Literal{
 		Kind:  "string",
-		Value: renderLiteral(registers[ins.X], false),
-	}
+		Value: renderLiteral(vm.Get(ins.X), false),
+	})
 
 	return nil
 }
@@ -33,11 +33,11 @@ type CastNumber struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *CastNumber) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	registers[ins.Result] = &ast.Literal{
+func (ins *CastNumber) Execute(_ *int, vm *VM) error {
+	vm.Set(ins.Result, &ast.Literal{
 		Kind:  "number",
-		Value: fmt.Sprintf("%d", int([]rune(registers[ins.X].Value)[0])),
-	}
+		Value: fmt.Sprintf("%d", int([]rune(vm.Get(ins.X).Value)[0])),
+	})
 
 	return nil
 }
@@ -53,11 +53,11 @@ type CastChar struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *CastChar) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	registers[ins.Result] = &ast.Literal{
+func (ins *CastChar) Execute(_ *int, vm *VM) error {
+	vm.Set(ins.Result, &ast.Literal{
 		Kind:  "char",
-		Value: fmt.Sprintf("%c", number.Int(number.NewNumber(registers[ins.X].Value))),
-	}
+		Value: fmt.Sprintf("%c", number.Int(number.NewNumber(vm.Get(ins.X).Value))),
+	})
 
 	return nil
 }

--- a/vm/combine.go
+++ b/vm/combine.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"fmt"
 
-	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 )
 
@@ -13,9 +12,9 @@ type Combine struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Combine) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	registers[ins.Result] = asttest.NewLiteralData(
-		[]byte(registers[ins.Left].Value + registers[ins.Right].Value))
+func (ins *Combine) Execute(_ *int, vm *VM) error {
+	vm.Set(ins.Result, asttest.NewLiteralData(
+		[]byte(vm.Get(ins.Left).Value+vm.Get(ins.Right).Value)))
 
 	return nil
 }

--- a/vm/combine_test.go
+++ b/vm/combine_test.go
@@ -24,7 +24,10 @@ func TestCombine_Execute(t *testing.T) {
 				"1": asttest.NewLiteralData(test.right),
 			}
 			ins := &vm.Combine{Left: "0", Right: "1", Result: "2"}
-			assert.NoError(t, ins.Execute(registers, nil, nil))
+			vm := &vm.VM{
+				Stack: []map[vm.Register]*ast.Literal{registers},
+			}
+			assert.NoError(t, ins.Execute(nil, vm))
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}

--- a/vm/concat.go
+++ b/vm/concat.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"fmt"
 
-	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 )
 
@@ -13,9 +12,9 @@ type Concat struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Concat) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	registers[ins.Result] = asttest.NewLiteralString(
-		registers[ins.Left].Value + registers[ins.Right].Value)
+func (ins *Concat) Execute(_ *int, vm *VM) error {
+	vm.Set(ins.Result, asttest.NewLiteralString(
+		vm.Get(ins.Left).Value+vm.Get(ins.Right).Value))
 
 	return nil
 }

--- a/vm/concat_test.go
+++ b/vm/concat_test.go
@@ -24,7 +24,10 @@ func TestConcat_Execute(t *testing.T) {
 				"1": asttest.NewLiteralString(test.right),
 			}
 			ins := &vm.Concat{Left: "0", Right: "1", Result: "2"}
-			assert.NoError(t, ins.Execute(registers, nil, nil))
+			vm := &vm.VM{
+				Stack: []map[vm.Register]*ast.Literal{registers},
+			}
+			assert.NoError(t, ins.Execute(nil, vm))
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}

--- a/vm/divide.go
+++ b/vm/divide.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"fmt"
 
-	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/number"
 )
@@ -14,18 +13,19 @@ type Divide struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Divide) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
+func (ins *Divide) Execute(_ *int, vm *VM) error {
 	divide, err := number.Divide(
-		number.NewNumber(registers[ins.Left].Value),
-		number.NewNumber(registers[ins.Right].Value),
+		number.NewNumber(vm.Get(ins.Left).Value),
+		number.NewNumber(vm.Get(ins.Right).Value),
 	)
 	if err != nil {
 		// TODO(elliot): This needs to be the same precision of zero.
-		registers[ins.Result] = asttest.NewLiteralNumber("0")
+		vm.Set(ins.Result, asttest.NewLiteralNumber("0"))
 		return err
 	}
 
-	registers[ins.Result] = asttest.NewLiteralNumber(divide.String())
+	vm.Set(ins.Result, asttest.NewLiteralNumber(divide.String()))
+
 	return nil
 }
 

--- a/vm/divide_test.go
+++ b/vm/divide_test.go
@@ -27,7 +27,10 @@ func TestDivide_Execute(t *testing.T) {
 				"1": asttest.NewLiteralNumber(test.right),
 			}
 			ins := &vm.Divide{Left: "0", Right: "1", Result: "2"}
-			assert.Equal(t, test.err, ins.Execute(registers, nil, nil))
+			vm := &vm.VM{
+				Stack: []map[vm.Register]*ast.Literal{registers},
+			}
+			assert.Equal(t, test.err, ins.Execute(nil, vm))
 			actual := number.NewNumber(registers[ins.Result].Value)
 			assert.Equal(t, test.expected, number.Format(actual, -1))
 		})

--- a/vm/equal.go
+++ b/vm/equal.go
@@ -15,11 +15,11 @@ type EqualNumber struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *EqualNumber) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	registers[ins.Result] = asttest.NewLiteralBool(numbersAreEqual(
-		registers[ins.Left],
-		registers[ins.Right],
-	))
+func (ins *EqualNumber) Execute(_ *int, vm *VM) error {
+	vm.Set(ins.Result, asttest.NewLiteralBool(numbersAreEqual(
+		vm.Get(ins.Left),
+		vm.Get(ins.Right),
+	)))
 
 	return nil
 }
@@ -44,9 +44,9 @@ type Equal struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Equal) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	registers[ins.Result] = asttest.NewLiteralBool(compareValue(
-		registers[ins.Left], registers[ins.Right]))
+func (ins *Equal) Execute(_ *int, vm *VM) error {
+	vm.Set(ins.Result, asttest.NewLiteralBool(compareValue(
+		vm.Get(ins.Left), vm.Get(ins.Right))))
 
 	return nil
 }

--- a/vm/equal_test.go
+++ b/vm/equal_test.go
@@ -50,7 +50,10 @@ func TestEqual_Execute(t *testing.T) {
 				"1": test.right,
 			}
 			ins := &vm.Equal{Left: "0", Right: "1", Result: "2"}
-			assert.NoError(t, ins.Execute(registers, nil, nil))
+			vm := &vm.VM{
+				Stack: []map[vm.Register]*ast.Literal{registers},
+			}
+			assert.NoError(t, ins.Execute(nil, vm))
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}
@@ -75,7 +78,10 @@ func TestEqualNumber_Execute(t *testing.T) {
 				"1": test.right,
 			}
 			ins := &vm.EqualNumber{Left: "0", Right: "1", Result: "2"}
-			assert.NoError(t, ins.Execute(registers, nil, nil))
+			vm := &vm.VM{
+				Stack: []map[vm.Register]*ast.Literal{registers},
+			}
+			assert.NoError(t, ins.Execute(nil, vm))
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}

--- a/vm/error_scope.go
+++ b/vm/error_scope.go
@@ -2,8 +2,6 @@ package vm
 
 import (
 	"fmt"
-
-	"github.com/elliotchance/ok/ast"
 )
 
 // On is a pragma for the vm to handle errors. It can also be used to indicate
@@ -16,7 +14,7 @@ type On struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *On) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
+func (ins *On) Execute(_ *int, vm *VM) error {
 	// Nothing happens here because On is just a pragma for the VM to look
 	// forward to find the error handler.
 	return nil

--- a/vm/finally.go
+++ b/vm/finally.go
@@ -2,8 +2,6 @@ package vm
 
 import (
 	"fmt"
-
-	"github.com/elliotchance/ok/ast"
 )
 
 // Finally will activate or deactivate a finally block.
@@ -13,7 +11,7 @@ type Finally struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Finally) Execute(registers map[Register]*ast.Literal, _ *int, vm *VM) error {
+func (ins *Finally) Execute(_ *int, vm *VM) error {
 	vm.FinallyBlocks[len(vm.FinallyBlocks)-1][ins.Index].Run = ins.Run
 
 	return nil

--- a/vm/greater_than.go
+++ b/vm/greater_than.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"fmt"
 
-	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/number"
 )
@@ -14,11 +13,11 @@ type GreaterThanNumber struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *GreaterThanNumber) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	registers[ins.Result] = asttest.NewLiteralBool(number.Cmp(
-		number.NewNumber(registers[ins.Left].Value),
-		number.NewNumber(registers[ins.Right].Value),
-	) > 0)
+func (ins *GreaterThanNumber) Execute(_ *int, vm *VM) error {
+	vm.Set(ins.Result, asttest.NewLiteralBool(number.Cmp(
+		number.NewNumber(vm.Get(ins.Left).Value),
+		number.NewNumber(vm.Get(ins.Right).Value),
+	) > 0))
 
 	return nil
 }
@@ -34,10 +33,10 @@ type GreaterThanString struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *GreaterThanString) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	registers[ins.Result] = asttest.NewLiteralBool(
-		registers[ins.Left].Value > registers[ins.Right].Value,
-	)
+func (ins *GreaterThanString) Execute(_ *int, vm *VM) error {
+	vm.Set(ins.Result, asttest.NewLiteralBool(
+		vm.Get(ins.Left).Value > vm.Get(ins.Right).Value,
+	))
 
 	return nil
 }

--- a/vm/greater_than_equal.go
+++ b/vm/greater_than_equal.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"fmt"
 
-	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/number"
 )
@@ -14,11 +13,11 @@ type GreaterThanEqualNumber struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *GreaterThanEqualNumber) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	registers[ins.Result] = asttest.NewLiteralBool(number.Cmp(
-		number.NewNumber(registers[ins.Left].Value),
-		number.NewNumber(registers[ins.Right].Value),
-	) >= 0)
+func (ins *GreaterThanEqualNumber) Execute(_ *int, vm *VM) error {
+	vm.Set(ins.Result, asttest.NewLiteralBool(number.Cmp(
+		number.NewNumber(vm.Get(ins.Left).Value),
+		number.NewNumber(vm.Get(ins.Right).Value),
+	) >= 0))
 
 	return nil
 }
@@ -34,10 +33,10 @@ type GreaterThanEqualString struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *GreaterThanEqualString) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	registers[ins.Result] = asttest.NewLiteralBool(
-		registers[ins.Left].Value >= registers[ins.Right].Value,
-	)
+func (ins *GreaterThanEqualString) Execute(_ *int, vm *VM) error {
+	vm.Set(ins.Result, asttest.NewLiteralBool(
+		vm.Get(ins.Left).Value >= vm.Get(ins.Right).Value,
+	))
 
 	return nil
 }

--- a/vm/greater_than_equal_test.go
+++ b/vm/greater_than_equal_test.go
@@ -29,7 +29,10 @@ func TestGreaterThanEqualString_Execute(t *testing.T) {
 				"1": test.right,
 			}
 			ins := &vm.GreaterThanEqualString{Left: "0", Right: "1", Result: "2"}
-			assert.NoError(t, ins.Execute(registers, nil, nil))
+			vm := &vm.VM{
+				Stack: []map[vm.Register]*ast.Literal{registers},
+			}
+			assert.NoError(t, ins.Execute(nil, vm))
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}
@@ -54,7 +57,10 @@ func TestGreaterThanEqualNumber_Execute(t *testing.T) {
 				"1": test.right,
 			}
 			ins := &vm.GreaterThanEqualNumber{Left: "0", Right: "1", Result: "2"}
-			assert.NoError(t, ins.Execute(registers, nil, nil))
+			vm := &vm.VM{
+				Stack: []map[vm.Register]*ast.Literal{registers},
+			}
+			assert.NoError(t, ins.Execute(nil, vm))
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}

--- a/vm/greater_than_test.go
+++ b/vm/greater_than_test.go
@@ -29,7 +29,10 @@ func TestGreaterThanString_Execute(t *testing.T) {
 				"1": test.right,
 			}
 			ins := &vm.GreaterThanString{Left: "0", Right: "1", Result: "2"}
-			assert.NoError(t, ins.Execute(registers, nil, nil))
+			vm := &vm.VM{
+				Stack: []map[vm.Register]*ast.Literal{registers},
+			}
+			assert.NoError(t, ins.Execute(nil, vm))
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}
@@ -54,7 +57,10 @@ func TestGreaterThanNumber_Execute(t *testing.T) {
 				"1": test.right,
 			}
 			ins := &vm.GreaterThanNumber{Left: "0", Right: "1", Result: "2"}
-			assert.NoError(t, ins.Execute(registers, nil, nil))
+			vm := &vm.VM{
+				Stack: []map[vm.Register]*ast.Literal{registers},
+			}
+			assert.NoError(t, ins.Execute(nil, vm))
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -2,8 +2,6 @@ package vm
 
 import (
 	"fmt"
-
-	"github.com/elliotchance/ok/ast"
 )
 
 // An Instruction can be executed by the VM.
@@ -12,5 +10,5 @@ type Instruction interface {
 	// helpful for debugging and used directly by "ok asm".
 	fmt.Stringer
 
-	Execute(registers map[Register]*ast.Literal, currentInstruction *int, vm *VM) error
+	Execute(i *int, vm *VM) error
 }

--- a/vm/interpolate.go
+++ b/vm/interpolate.go
@@ -17,14 +17,14 @@ type Interpolate struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Interpolate) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
+func (ins *Interpolate) Execute(_ *int, vm *VM) error {
 	s := ""
 
 	for _, arg := range ins.Args {
-		s += renderLiteral(registers[arg], false)
+		s += renderLiteral(vm.Get(arg), false)
 	}
 
-	registers[ins.Result] = asttest.NewLiteralString(s)
+	vm.Set(ins.Result, asttest.NewLiteralString(s))
 
 	return nil
 }

--- a/vm/jump.go
+++ b/vm/jump.go
@@ -2,8 +2,6 @@ package vm
 
 import (
 	"fmt"
-
-	"github.com/elliotchance/ok/ast"
 )
 
 // Jump will jump to the instruction.
@@ -12,7 +10,7 @@ type Jump struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Jump) Execute(registers map[Register]*ast.Literal, i *int, _ *VM) error {
+func (ins *Jump) Execute(i *int, vm *VM) error {
 	*i = ins.To
 
 	return nil

--- a/vm/jump_unless.go
+++ b/vm/jump_unless.go
@@ -2,8 +2,6 @@ package vm
 
 import (
 	"fmt"
-
-	"github.com/elliotchance/ok/ast"
 )
 
 // JumpUnless will jump to the instruction if the expression is false.
@@ -13,8 +11,8 @@ type JumpUnless struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *JumpUnless) Execute(registers map[Register]*ast.Literal, i *int, _ *VM) error {
-	if registers[ins.Condition].Value != "true" {
+func (ins *JumpUnless) Execute(i *int, vm *VM) error {
+	if vm.Get(ins.Condition).Value != "true" {
 		*i = ins.To
 	}
 

--- a/vm/len.go
+++ b/vm/len.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 )
 
@@ -14,8 +13,8 @@ type Len struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Len) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	r := registers[ins.Argument]
+func (ins *Len) Execute(_ *int, vm *VM) error {
+	r := vm.Get(ins.Argument)
 	var result int
 	switch {
 	case strings.HasPrefix(r.Kind, "[]"):
@@ -31,7 +30,7 @@ func (ins *Len) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) erro
 		result = len(r.Value)
 	}
 
-	registers[ins.Result] = asttest.NewLiteralNumber(fmt.Sprintf("%d", result))
+	vm.Set(ins.Result, asttest.NewLiteralNumber(fmt.Sprintf("%d", result)))
 
 	return nil
 }

--- a/vm/len_test.go
+++ b/vm/len_test.go
@@ -26,7 +26,10 @@ func TestLen_Execute(t *testing.T) {
 				"0": test.x,
 			}
 			ins := &vm.Len{Argument: "0", Result: "1"}
-			assert.NoError(t, ins.Execute(registers, nil, nil))
+			vm := &vm.VM{
+				Stack: []map[vm.Register]*ast.Literal{registers},
+			}
+			assert.NoError(t, ins.Execute(nil, vm))
 			assert.Equal(t, test.expected, registers[ins.Result])
 		})
 	}

--- a/vm/less_than.go
+++ b/vm/less_than.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"fmt"
 
-	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/number"
 )
@@ -14,11 +13,11 @@ type LessThanNumber struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *LessThanNumber) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	registers[ins.Result] = asttest.NewLiteralBool(number.Cmp(
-		number.NewNumber(registers[ins.Left].Value),
-		number.NewNumber(registers[ins.Right].Value),
-	) < 0)
+func (ins *LessThanNumber) Execute(_ *int, vm *VM) error {
+	vm.Set(ins.Result, asttest.NewLiteralBool(number.Cmp(
+		number.NewNumber(vm.Get(ins.Left).Value),
+		number.NewNumber(vm.Get(ins.Right).Value),
+	) < 0))
 
 	return nil
 }
@@ -34,10 +33,10 @@ type LessThanString struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *LessThanString) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	registers[ins.Result] = asttest.NewLiteralBool(
-		registers[ins.Left].Value < registers[ins.Right].Value,
-	)
+func (ins *LessThanString) Execute(_ *int, vm *VM) error {
+	vm.Set(ins.Result, asttest.NewLiteralBool(
+		vm.Get(ins.Left).Value < vm.Get(ins.Right).Value,
+	))
 
 	return nil
 }

--- a/vm/less_than_equal.go
+++ b/vm/less_than_equal.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"fmt"
 
-	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/number"
 )
@@ -14,11 +13,11 @@ type LessThanEqualNumber struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *LessThanEqualNumber) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	registers[ins.Result] = asttest.NewLiteralBool(number.Cmp(
-		number.NewNumber(registers[ins.Left].Value),
-		number.NewNumber(registers[ins.Right].Value),
-	) <= 0)
+func (ins *LessThanEqualNumber) Execute(_ *int, vm *VM) error {
+	vm.Set(ins.Result, asttest.NewLiteralBool(number.Cmp(
+		number.NewNumber(vm.Get(ins.Left).Value),
+		number.NewNumber(vm.Get(ins.Right).Value),
+	) <= 0))
 
 	return nil
 }
@@ -34,10 +33,10 @@ type LessThanEqualString struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *LessThanEqualString) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	registers[ins.Result] = asttest.NewLiteralBool(
-		registers[ins.Left].Value <= registers[ins.Right].Value,
-	)
+func (ins *LessThanEqualString) Execute(_ *int, vm *VM) error {
+	vm.Set(ins.Result, asttest.NewLiteralBool(
+		vm.Get(ins.Left).Value <= vm.Get(ins.Right).Value,
+	))
 
 	return nil
 }

--- a/vm/less_than_equal_test.go
+++ b/vm/less_than_equal_test.go
@@ -29,7 +29,10 @@ func TestLessThanEqualString_Execute(t *testing.T) {
 				"1": test.right,
 			}
 			ins := &vm.LessThanEqualString{Left: "0", Right: "1", Result: "2"}
-			assert.NoError(t, ins.Execute(registers, nil, nil))
+			vm := &vm.VM{
+				Stack: []map[vm.Register]*ast.Literal{registers},
+			}
+			assert.NoError(t, ins.Execute(nil, vm))
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}
@@ -54,7 +57,10 @@ func TestLessThanEqualNumber_Execute(t *testing.T) {
 				"1": test.right,
 			}
 			ins := &vm.LessThanEqualNumber{Left: "0", Right: "1", Result: "2"}
-			assert.NoError(t, ins.Execute(registers, nil, nil))
+			vm := &vm.VM{
+				Stack: []map[vm.Register]*ast.Literal{registers},
+			}
+			assert.NoError(t, ins.Execute(nil, vm))
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}

--- a/vm/less_than_test.go
+++ b/vm/less_than_test.go
@@ -29,7 +29,10 @@ func TestLessThanString_Execute(t *testing.T) {
 				"1": test.right,
 			}
 			ins := &vm.LessThanString{Left: "0", Right: "1", Result: "2"}
-			assert.NoError(t, ins.Execute(registers, nil, nil))
+			vm := &vm.VM{
+				Stack: []map[vm.Register]*ast.Literal{registers},
+			}
+			assert.NoError(t, ins.Execute(nil, vm))
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}
@@ -54,7 +57,10 @@ func TestLessThanNumber_Execute(t *testing.T) {
 				"1": test.right,
 			}
 			ins := &vm.LessThanNumber{Left: "0", Right: "1", Result: "2"}
-			assert.NoError(t, ins.Execute(registers, nil, nil))
+			vm := &vm.VM{
+				Stack: []map[vm.Register]*ast.Literal{registers},
+			}
+			assert.NoError(t, ins.Execute(nil, vm))
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}

--- a/vm/log.go
+++ b/vm/log.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"fmt"
 
-	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/number"
 )
@@ -14,12 +13,12 @@ type Log struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Log) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	registers[ins.Result] = asttest.NewLiteralNumber(
+func (ins *Log) Execute(_ *int, vm *VM) error {
+	vm.Set(ins.Result, asttest.NewLiteralNumber(
 		number.Log(
-			number.NewNumber(registers[ins.X].Value),
+			number.NewNumber(vm.Get(ins.X).Value),
 		).String(),
-	)
+	))
 
 	return nil
 }

--- a/vm/map_alloc.go
+++ b/vm/map_alloc.go
@@ -13,10 +13,10 @@ type MapAllocNumber struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *MapAllocNumber) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	size := number.Int64(number.NewNumber(registers[ins.Size].Value))
+func (ins *MapAllocNumber) Execute(_ *int, vm *VM) error {
+	size := number.Int64(number.NewNumber(vm.Get(ins.Size).Value))
 
-	registers[ins.Result] = &ast.Literal{
+	vm.Set(ins.Result, &ast.Literal{
 		Kind: "{}number",
 
 		// Array must also be allocated because it will contain the keys for the
@@ -24,7 +24,7 @@ func (ins *MapAllocNumber) Execute(registers map[Register]*ast.Literal, _ *int, 
 		Array: make([]*ast.Literal, 0, size),
 
 		Map: make(map[string]*ast.Literal, size),
-	}
+	})
 
 	return nil
 }

--- a/vm/map_get.go
+++ b/vm/map_get.go
@@ -2,8 +2,6 @@ package vm
 
 import (
 	"fmt"
-
-	"github.com/elliotchance/ok/ast"
 )
 
 // MapGet gets a value from the map by its key.
@@ -12,9 +10,9 @@ type MapGet struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *MapGet) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	key := registers[ins.Key].Value
-	registers[ins.Result] = registers[ins.Map].Map[key]
+func (ins *MapGet) Execute(_ *int, vm *VM) error {
+	key := vm.Get(ins.Key).Value
+	vm.Set(ins.Result, vm.Get(ins.Map).Map[key])
 
 	return nil
 }

--- a/vm/map_set.go
+++ b/vm/map_set.go
@@ -2,8 +2,6 @@ package vm
 
 import (
 	"fmt"
-
-	"github.com/elliotchance/ok/ast"
 )
 
 // MapSet sets a number value to an index.
@@ -12,10 +10,10 @@ type MapSet struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *MapSet) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	key := registers[ins.Key].Value
-	registers[ins.Map].Map[key] = registers[ins.Value]
-	registers[ins.Map].Array = append(registers[ins.Map].Array, registers[ins.Key])
+func (ins *MapSet) Execute(_ *int, vm *VM) error {
+	key := vm.Get(ins.Key).Value
+	vm.Get(ins.Map).Map[key] = vm.Get(ins.Value)
+	vm.Get(ins.Map).Array = append(vm.Get(ins.Map).Array, vm.Get(ins.Key))
 
 	return nil
 }

--- a/vm/multiply.go
+++ b/vm/multiply.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"fmt"
 
-	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/number"
 )
@@ -14,13 +13,13 @@ type Multiply struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Multiply) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	registers[ins.Result] = asttest.NewLiteralNumber(
+func (ins *Multiply) Execute(_ *int, vm *VM) error {
+	vm.Set(ins.Result, asttest.NewLiteralNumber(
 		number.Multiply(
-			number.NewNumber(registers[ins.Left].Value),
-			number.NewNumber(registers[ins.Right].Value),
+			number.NewNumber(vm.Get(ins.Left).Value),
+			number.NewNumber(vm.Get(ins.Right).Value),
 		).String(),
-	)
+	))
 
 	return nil
 }

--- a/vm/multiply_test.go
+++ b/vm/multiply_test.go
@@ -24,7 +24,10 @@ func TestMultiply_Execute(t *testing.T) {
 				"1": asttest.NewLiteralNumber(test.right),
 			}
 			ins := &vm.Multiply{Left: "0", Right: "1", Result: "2"}
-			assert.NoError(t, ins.Execute(registers, nil, nil))
+			vm := &vm.VM{
+				Stack: []map[vm.Register]*ast.Literal{registers},
+			}
+			assert.NoError(t, ins.Execute(nil, vm))
 			actual := number.NewNumber(registers[ins.Result].Value)
 			assert.Equal(t, test.expected, number.Format(actual, -1))
 		})

--- a/vm/next_array.go
+++ b/vm/next_array.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"fmt"
 
-	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/number"
 )
@@ -18,15 +17,15 @@ type NextArray struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *NextArray) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	array := registers[ins.Array].Array
-	pos := number.Int(number.NewNumber(registers[ins.Cursor].Value))
+func (ins *NextArray) Execute(_ *int, vm *VM) error {
+	array := vm.Get(ins.Array).Array
+	pos := number.Int(number.NewNumber(vm.Get(ins.Cursor).Value))
 	hasMore := pos < len(array)
-	registers[ins.Result] = asttest.NewLiteralBool(hasMore)
+	vm.Set(ins.Result, asttest.NewLiteralBool(hasMore))
 	if hasMore {
-		registers[ins.KeyResult] = asttest.NewLiteralNumber(fmt.Sprintf("%d", pos))
-		registers[ins.ValueResult] = array[pos]
-		registers[ins.Cursor] = asttest.NewLiteralNumber(fmt.Sprintf("%d", pos+1))
+		vm.Set(ins.KeyResult, asttest.NewLiteralNumber(fmt.Sprintf("%d", pos)))
+		vm.Set(ins.ValueResult, array[pos])
+		vm.Set(ins.Cursor, asttest.NewLiteralNumber(fmt.Sprintf("%d", pos+1)))
 	}
 
 	return nil

--- a/vm/next_map.go
+++ b/vm/next_map.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"fmt"
 
-	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/number"
 )
@@ -18,17 +17,17 @@ type NextMap struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *NextMap) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	array := registers[ins.Map].Array
-	pos := number.Int(number.NewNumber(registers[ins.Cursor].Value))
+func (ins *NextMap) Execute(_ *int, vm *VM) error {
+	array := vm.Get(ins.Map).Array
+	pos := number.Int(number.NewNumber(vm.Get(ins.Cursor).Value))
 
 	hasMore := pos < len(array)
-	registers[ins.Result] = asttest.NewLiteralBool(hasMore)
+	vm.Set(ins.Result, asttest.NewLiteralBool(hasMore))
 	if hasMore {
-		m := registers[ins.Map].Map
-		registers[ins.KeyResult] = array[pos]
-		registers[ins.ValueResult] = m[array[pos].Value]
-		registers[ins.Cursor].Value = fmt.Sprintf("%d", pos+1)
+		m := vm.Get(ins.Map).Map
+		vm.Set(ins.KeyResult, array[pos])
+		vm.Set(ins.ValueResult, m[array[pos].Value])
+		vm.Set(ins.Cursor, asttest.NewLiteralNumber(fmt.Sprintf("%d", pos+1)))
 	}
 
 	return nil

--- a/vm/next_string.go
+++ b/vm/next_string.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"fmt"
 
-	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/number"
 )
@@ -18,15 +17,15 @@ type NextString struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *NextString) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	str := []rune(registers[ins.Str].Value)
-	pos := number.Int(number.NewNumber(registers[ins.Cursor].Value))
+func (ins *NextString) Execute(_ *int, vm *VM) error {
+	str := []rune(vm.Get(ins.Str).Value)
+	pos := number.Int(number.NewNumber(vm.Get(ins.Cursor).Value))
 	hasMore := pos < len(str)
-	registers[ins.Result] = asttest.NewLiteralBool(hasMore)
+	vm.Set(ins.Result, asttest.NewLiteralBool(hasMore))
 	if hasMore {
-		registers[ins.KeyResult] = asttest.NewLiteralNumber(fmt.Sprintf("%d", pos))
-		registers[ins.ValueResult] = asttest.NewLiteralChar(str[pos])
-		registers[ins.Cursor] = asttest.NewLiteralNumber(fmt.Sprintf("%d", pos+1))
+		vm.Set(ins.KeyResult, asttest.NewLiteralNumber(fmt.Sprintf("%d", pos)))
+		vm.Set(ins.ValueResult, asttest.NewLiteralChar(str[pos]))
+		vm.Set(ins.Cursor, asttest.NewLiteralNumber(fmt.Sprintf("%d", pos+1)))
 	}
 
 	return nil

--- a/vm/not.go
+++ b/vm/not.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"fmt"
 
-	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 )
 
@@ -13,10 +12,10 @@ type Not struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Not) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	registers[ins.Result] = asttest.NewLiteralBool(
-		!(registers[ins.Left].Value == "true"),
-	)
+func (ins *Not) Execute(_ *int, vm *VM) error {
+	vm.Set(ins.Result, asttest.NewLiteralBool(
+		!(vm.Get(ins.Left).Value == "true"),
+	))
 
 	return nil
 }

--- a/vm/not_equal.go
+++ b/vm/not_equal.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"fmt"
 
-	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 )
 
@@ -13,11 +12,11 @@ type NotEqualNumber struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *NotEqualNumber) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	registers[ins.Result] = asttest.NewLiteralBool(!numbersAreEqual(
-		registers[ins.Left],
-		registers[ins.Right],
-	))
+func (ins *NotEqualNumber) Execute(_ *int, vm *VM) error {
+	vm.Set(ins.Result, asttest.NewLiteralBool(!numbersAreEqual(
+		vm.Get(ins.Left),
+		vm.Get(ins.Right),
+	)))
 
 	return nil
 }
@@ -36,10 +35,10 @@ type NotEqual struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *NotEqual) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	registers[ins.Result] = asttest.NewLiteralBool(!compareValue(
-		registers[ins.Left], registers[ins.Right],
-	))
+func (ins *NotEqual) Execute(_ *int, vm *VM) error {
+	vm.Set(ins.Result, asttest.NewLiteralBool(!compareValue(
+		vm.Get(ins.Left), vm.Get(ins.Right),
+	)))
 
 	return nil
 }

--- a/vm/not_equal_test.go
+++ b/vm/not_equal_test.go
@@ -50,7 +50,10 @@ func TestNotEqual_Execute(t *testing.T) {
 				"1": test.right,
 			}
 			ins := &vm.NotEqual{Left: "0", Right: "1", Result: "2"}
-			assert.NoError(t, ins.Execute(registers, nil, nil))
+			vm := &vm.VM{
+				Stack: []map[vm.Register]*ast.Literal{registers},
+			}
+			assert.NoError(t, ins.Execute(nil, vm))
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}
@@ -75,7 +78,10 @@ func TestNotEqualNumber_Execute(t *testing.T) {
 				"1": test.right,
 			}
 			ins := &vm.NotEqualNumber{Left: "0", Right: "1", Result: "2"}
-			assert.NoError(t, ins.Execute(registers, nil, nil))
+			vm := &vm.VM{
+				Stack: []map[vm.Register]*ast.Literal{registers},
+			}
+			assert.NoError(t, ins.Execute(nil, vm))
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}

--- a/vm/not_test.go
+++ b/vm/not_test.go
@@ -23,7 +23,10 @@ func TestNot_Execute(t *testing.T) {
 				"0": asttest.NewLiteralBool(test.left),
 			}
 			ins := &vm.Not{Left: "0", Result: "1"}
-			assert.NoError(t, ins.Execute(registers, nil, nil))
+			vm := &vm.VM{
+				Stack: []map[vm.Register]*ast.Literal{registers},
+			}
+			assert.NoError(t, ins.Execute(nil, vm))
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}

--- a/vm/or.go
+++ b/vm/or.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"fmt"
 
-	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 )
 
@@ -13,11 +12,11 @@ type Or struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Or) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	registers[ins.Result] = asttest.NewLiteralBool(
-		(registers[ins.Left].Value == "true") ||
-			(registers[ins.Right].Value == "true"),
-	)
+func (ins *Or) Execute(_ *int, vm *VM) error {
+	vm.Set(ins.Result, asttest.NewLiteralBool(
+		(vm.Get(ins.Left).Value == "true") ||
+			(vm.Get(ins.Right).Value == "true"),
+	))
 
 	return nil
 }

--- a/vm/or_test.go
+++ b/vm/or_test.go
@@ -26,7 +26,10 @@ func TestOr_Execute(t *testing.T) {
 				"1": asttest.NewLiteralBool(test.right),
 			}
 			ins := &vm.Or{Left: "0", Right: "1", Result: "2"}
-			assert.NoError(t, ins.Execute(registers, nil, nil))
+			vm := &vm.VM{
+				Stack: []map[vm.Register]*ast.Literal{registers},
+			}
+			assert.NoError(t, ins.Execute(nil, vm))
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}

--- a/vm/power.go
+++ b/vm/power.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"fmt"
 
-	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/number"
 )
@@ -14,13 +13,13 @@ type Power struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Power) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	registers[ins.Result] = asttest.NewLiteralNumber(
+func (ins *Power) Execute(_ *int, vm *VM) error {
+	vm.Set(ins.Result, asttest.NewLiteralNumber(
 		number.Pow(
-			number.NewNumber(registers[ins.Base].Value),
-			number.NewNumber(registers[ins.Power].Value),
+			number.NewNumber(vm.Get(ins.Base).Value),
+			number.NewNumber(vm.Get(ins.Power).Value),
 		).String(),
-	)
+	))
 
 	return nil
 }

--- a/vm/print.go
+++ b/vm/print.go
@@ -2,8 +2,6 @@ package vm
 
 import (
 	"fmt"
-
-	"github.com/elliotchance/ok/ast"
 )
 
 // Print will output a string to stdout.
@@ -12,13 +10,13 @@ type Print struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Print) Execute(registers map[Register]*ast.Literal, _ *int, vm *VM) error {
+func (ins *Print) Execute(_ *int, vm *VM) error {
 	for i, register := range ins.Arguments {
 		if i > 0 {
 			fmt.Fprint(vm.Stdout, " ")
 		}
 
-		fmt.Fprint(vm.Stdout, renderLiteral(registers[register], false))
+		fmt.Fprint(vm.Stdout, renderLiteral(vm.Get(register), false))
 	}
 
 	fmt.Fprint(vm.Stdout, "\n")

--- a/vm/print_test.go
+++ b/vm/print_test.go
@@ -130,7 +130,11 @@ func TestPrint_Execute(t *testing.T) {
 			ins := &vm.Print{
 				Arguments: arguments,
 			}
-			assert.NoError(t, ins.Execute(registers, nil, &vm.VM{Stdout: buf}))
+			vm := &vm.VM{
+				Stack:  []map[vm.Register]*ast.Literal{registers},
+				Stdout: buf,
+			}
+			assert.NoError(t, ins.Execute(nil, vm))
 			assert.Equal(t, test.expectedStdout, buf.String())
 		})
 	}

--- a/vm/raise.go
+++ b/vm/raise.go
@@ -2,8 +2,6 @@ package vm
 
 import (
 	"fmt"
-
-	"github.com/elliotchance/ok/ast"
 )
 
 // Raise put the VM into an error mode. The VM will look for an error handler.
@@ -16,9 +14,9 @@ type Raise struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Raise) Execute(registers map[Register]*ast.Literal, _ *int, vm *VM) error {
+func (ins *Raise) Execute(_ *int, vm *VM) error {
 	vm.ErrType = ins.Type
-	vm.ErrValue = registers[ins.Err]
+	vm.ErrValue = vm.Get(ins.Err)
 
 	return nil
 }

--- a/vm/remainder.go
+++ b/vm/remainder.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"fmt"
 
-	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/number"
 )
@@ -15,18 +14,19 @@ type Remainder struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Remainder) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
+func (ins *Remainder) Execute(_ *int, vm *VM) error {
 	divide, err := number.Remainder(
-		number.NewNumber(registers[ins.Left].Value),
-		number.NewNumber(registers[ins.Right].Value),
+		number.NewNumber(vm.Get(ins.Left).Value),
+		number.NewNumber(vm.Get(ins.Right).Value),
 	)
 	if err != nil {
 		// TODO(elliot): This needs to be the same precision of zero.
-		registers[ins.Result] = asttest.NewLiteralNumber("0")
+		vm.Set(ins.Result, asttest.NewLiteralNumber("0"))
 		return err
 	}
 
-	registers[ins.Result] = asttest.NewLiteralNumber(divide.String())
+	vm.Set(ins.Result, asttest.NewLiteralNumber(divide.String()))
+
 	return nil
 }
 

--- a/vm/remainder_test.go
+++ b/vm/remainder_test.go
@@ -26,7 +26,10 @@ func TestRemainder_Execute(t *testing.T) {
 				"1": asttest.NewLiteralNumber(test.right),
 			}
 			ins := &vm.Remainder{Left: "0", Right: "1", Result: "2"}
-			assert.Equal(t, test.err, ins.Execute(registers, nil, nil))
+			vm := &vm.VM{
+				Stack: []map[vm.Register]*ast.Literal{registers},
+			}
+			assert.Equal(t, test.err, ins.Execute(nil, vm))
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}

--- a/vm/return.go
+++ b/vm/return.go
@@ -2,8 +2,6 @@ package vm
 
 import (
 	"fmt"
-
-	"github.com/elliotchance/ok/ast"
 )
 
 // Return tells the VM to jump out of this function.
@@ -12,7 +10,7 @@ type Return struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Return) Execute(registers map[Register]*ast.Literal, _ *int, vm *VM) error {
+func (ins *Return) Execute(_ *int, vm *VM) error {
 	vm.Return = ins.Results
 
 	return nil

--- a/vm/string_index.go
+++ b/vm/string_index.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"fmt"
 
-	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/number"
 )
@@ -14,11 +13,11 @@ type StringIndex struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *StringIndex) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	index := number.Int64(number.NewNumber(registers[ins.Index].Value))
+func (ins *StringIndex) Execute(_ *int, vm *VM) error {
+	index := number.Int64(number.NewNumber(vm.Get(ins.Index).Value))
 
 	// TODO(elliot): This won't work with multibyte characters.
-	registers[ins.Result] = asttest.NewLiteralChar([]rune(registers[ins.Str].Value)[index])
+	vm.Set(ins.Result, asttest.NewLiteralChar([]rune(vm.Get(ins.Str).Value)[index]))
 
 	return nil
 }

--- a/vm/subtract.go
+++ b/vm/subtract.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"fmt"
 
-	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/number"
 )
@@ -14,13 +13,13 @@ type Subtract struct {
 }
 
 // Execute implements the Instruction interface for the VM.
-func (ins *Subtract) Execute(registers map[Register]*ast.Literal, _ *int, _ *VM) error {
-	registers[ins.Result] = asttest.NewLiteralNumber(
+func (ins *Subtract) Execute(_ *int, vm *VM) error {
+	vm.Set(ins.Result, asttest.NewLiteralNumber(
 		number.Subtract(
-			number.NewNumber(registers[ins.Left].Value),
-			number.NewNumber(registers[ins.Right].Value),
+			number.NewNumber(vm.Get(ins.Left).Value),
+			number.NewNumber(vm.Get(ins.Right).Value),
 		).String(),
-	)
+	))
 
 	return nil
 }

--- a/vm/subtract_test.go
+++ b/vm/subtract_test.go
@@ -23,7 +23,10 @@ func TestSubtract_Execute(t *testing.T) {
 				"1": asttest.NewLiteralNumber(test.right),
 			}
 			ins := &vm.Subtract{Left: "0", Right: "1", Result: "2"}
-			assert.NoError(t, ins.Execute(registers, nil, nil))
+			vm := &vm.VM{
+				Stack: []map[vm.Register]*ast.Literal{registers},
+			}
+			assert.NoError(t, ins.Execute(nil, vm))
 			assert.Equal(t, test.expected, registers[ins.Result].Value)
 		})
 	}


### PR DESCRIPTION
This doesn't change any logic, but simplifies the instruction interface
to make it possible in the coming patches to have more than just
registers. We will also need states and scopes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/ok/51)
<!-- Reviewable:end -->
