### PR TITLE
Dump VM on panic

### DIFF
--- a/cmd/asm/main.go
+++ b/cmd/asm/main.go
@@ -26,7 +26,12 @@ func (*Command) Run(args []string) {
 	pkg, errs := compiler.CompilePackage(args[0], false)
 	util.CheckErrorsWithExit(errs)
 
-	for _, fnName := range args[1:] {
+	for i, fnName := range args[1:] {
+		// Just for vanity, put an empty line between functions.
+		if i > 0 {
+			fmt.Println()
+		}
+
 		fn, exists := pkg.FuncDefs[fnName]
 		if !exists {
 			// TODO(elliot): This could be handled more gracefully.


### PR DESCRIPTION
At some point this will not be necessary, but right now it's vital for
debugging that when a panic occurs we print out the memory and the
position of failure. This can be examined with "ok asm".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/ok/53)
<!-- Reviewable:end -->
