### PR TITLE
Refactor how object states work

### DIFF
--- a/ast/literal.go
+++ b/ast/literal.go
@@ -2,6 +2,8 @@ package ast
 
 import (
 	"encoding/json"
+
+	"github.com/elliotchance/ok/compiler/kind"
 )
 
 // Literal represents a literal of any type.
@@ -26,13 +28,19 @@ func (node *Literal) Position() string {
 // String is the human-readable representation of the value. To make it easier
 // we just output everything as JSON.
 func (node *Literal) String() string {
+	var x interface{} = node.Value
+
+	switch {
+	case kind.IsArray(node.Kind):
+		x = node.Array
+
+	case kind.IsMap(node.Kind):
+		x = node.Map
+	}
+
 	// Ignore error, it shouldn't happen, and if it does there is nothing
 	// sensible we can do in that case.
-	v, _ := json.Marshal(node.Value)
-
-	// TODO(elliot): This doesn't handle non-scalar types. However, they can
-	//  only exist at runtime so for what this function is used for it may not
-	//  be an issue.
+	v, _ := json.Marshal(x)
 
 	return string(v)
 }

--- a/compiler/assign.go
+++ b/compiler/assign.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/elliotchance/ok/ast"
-	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/vm"
 )
 
@@ -49,27 +48,11 @@ func compileAssign(compiledFunc *vm.CompiledFunc, node *ast.Assign, fns map[stri
 
 			compiledFunc.NewVariable(variableName, rr.kind)
 
-			// When in an object we need to change an assign into a MapSet for
-			// this instance variable.
-			if compiledFunc.ObjectRegister != "" {
-				keyRegister := compiledFunc.NextRegister()
-				compiledFunc.Append(&vm.Assign{
-					VariableName: keyRegister,
-					Value:        asttest.NewLiteralString(variableName),
-				})
-
-				compiledFunc.Append(&vm.MapSet{
-					Map:   compiledFunc.ObjectRegister,
-					Key:   keyRegister,
-					Value: rr.result,
-				})
-			} else {
-				ins := &vm.Assign{
-					VariableName: vm.Register(variableName),
-					Register:     rr.result,
-				}
-				compiledFunc.Append(ins)
+			ins := &vm.Assign{
+				VariableName: vm.Register(variableName),
+				Register:     rr.result,
 			}
+			compiledFunc.Append(ins)
 
 		case *ast.Key:
 			arrayOrMapResults, arrayOrMapKind, err := compileExpr(compiledFunc,

--- a/compiler/file_test.go
+++ b/compiler/file_test.go
@@ -247,24 +247,11 @@ func TestCompileFile(t *testing.T) {
 						Registers: 1,
 					},
 					"Person": {
-						Variables:      map[string]string{},
-						ObjectRegister: "2",
-						Registers:      2,
+						Variables: map[string]string{},
 						Instructions: []vm.Instruction{
-							// alloc instance
-							&vm.Assign{
-								VariableName: "1",
-								Value:        asttest.NewLiteralNumber("0"),
-							},
-							&vm.MapAlloc{
-								Kind:   "{}any",
-								Size:   "1",
-								Result: "2",
-							},
-
 							// return instance
 							&vm.Return{
-								Results: []vm.Register{"2"},
+								Results: []vm.Register{vm.StateRegister},
 							},
 						},
 					},

--- a/compiler/func.go
+++ b/compiler/func.go
@@ -2,7 +2,6 @@ package compiler
 
 import (
 	"github.com/elliotchance/ok/ast"
-	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/vm"
 )
 
@@ -18,27 +17,6 @@ func CompileFunc(fn *ast.Func, fns map[string]*ast.Func) (*vm.CompiledFunc, erro
 	//
 	// The parser has already corrected the missing return type.
 	isObject := len(fn.Returns) == 1 && fn.Returns[0] == fn.Name
-	if isObject {
-		// Size will always be zero. We append everything to an empty map right
-		// now since there's no real benefit to allocating the map at the full
-		// size.
-		sizeRegister := compiled.NextRegister()
-		compiled.Append(&vm.Assign{
-			VariableName: sizeRegister,
-			Value:        asttest.NewLiteralNumber("0"),
-		})
-
-		// objectRegister will contain all the state, and also must be returned
-		// at the end.
-		compiled.ObjectRegister = compiled.NextRegister()
-		compiled.Append(&vm.MapAlloc{
-			// TODO(elliot): This should probably be the actual type returned?
-			Kind: "{}any",
-
-			Size:   sizeRegister,
-			Result: compiled.ObjectRegister,
-		})
-	}
 
 	// Load the arguments from the registers.
 	for _, arg := range fn.Arguments {
@@ -56,7 +34,7 @@ func CompileFunc(fn *ast.Func, fns map[string]*ast.Func) (*vm.CompiledFunc, erro
 	// If this is an object, always returns its state.
 	if isObject {
 		compiled.Append(&vm.Return{
-			Results: []vm.Register{compiled.ObjectRegister},
+			Results: []vm.Register{vm.StateRegister},
 		})
 	}
 

--- a/compiler/object_test.go
+++ b/compiler/object_test.go
@@ -23,20 +23,9 @@ func TestObject(t *testing.T) {
 				Returns: []string{"Foo"},
 			},
 			expected: []vm.Instruction{
-				// alloc instance
-				&vm.Assign{
-					VariableName: "1",
-					Value:        asttest.NewLiteralNumber("0"),
-				},
-				&vm.MapAlloc{
-					Kind:   "{}any",
-					Size:   "1",
-					Result: "2",
-				},
-
 				// return instance
 				&vm.Return{
-					Results: []vm.Register{"2"},
+					Results: []vm.Register{vm.StateRegister},
 				},
 			},
 		},
@@ -56,35 +45,19 @@ func TestObject(t *testing.T) {
 				},
 			},
 			expected: []vm.Instruction{
-				// alloc instance
-				&vm.Assign{
-					VariableName: "1",
-					Value:        asttest.NewLiteralNumber("0"),
-				},
-				&vm.MapAlloc{
-					Kind:   "{}any",
-					Size:   "1",
-					Result: "2",
-				},
-
 				// bar = 123
 				&vm.Assign{
-					VariableName: "3",
+					VariableName: "1",
 					Value:        asttest.NewLiteralNumber("123"),
 				},
 				&vm.Assign{
-					VariableName: "4",
-					Value:        asttest.NewLiteralString("bar"),
-				},
-				&vm.MapSet{
-					Map:   "2",
-					Key:   "4",
-					Value: "3",
+					VariableName: "bar",
+					Register:     "1",
 				},
 
 				// return instance
 				&vm.Return{
-					Results: []vm.Register{"2"},
+					Results: []vm.Register{vm.StateRegister},
 				},
 			},
 		},

--- a/vm/func.go
+++ b/vm/func.go
@@ -3,12 +3,11 @@ package vm
 import "fmt"
 
 type CompiledFunc struct {
-	Arguments      []string
-	Instructions   []Instruction
-	Registers      int
-	Variables      map[string]string // name: type
-	ObjectRegister Register
-	Finally        [][]Instruction
+	Arguments    []string
+	Instructions []Instruction
+	Registers    int
+	Variables    map[string]string // name: type
+	Finally      [][]Instruction
 }
 
 type FinallyBlock struct {

--- a/vm/next_array.go
+++ b/vm/next_array.go
@@ -23,7 +23,11 @@ func (ins *NextArray) Execute(_ *int, vm *VM) error {
 	hasMore := pos < len(array)
 	vm.Set(ins.Result, asttest.NewLiteralBool(hasMore))
 	if hasMore {
-		vm.Set(ins.KeyResult, asttest.NewLiteralNumber(fmt.Sprintf("%d", pos)))
+		// Key may be optionally set.
+		if ins.KeyResult != "" {
+			vm.Set(ins.KeyResult, asttest.NewLiteralNumber(fmt.Sprintf("%d", pos)))
+		}
+
 		vm.Set(ins.ValueResult, array[pos])
 		vm.Set(ins.Cursor, asttest.NewLiteralNumber(fmt.Sprintf("%d", pos+1)))
 	}

--- a/vm/next_map.go
+++ b/vm/next_map.go
@@ -25,7 +25,12 @@ func (ins *NextMap) Execute(_ *int, vm *VM) error {
 	vm.Set(ins.Result, asttest.NewLiteralBool(hasMore))
 	if hasMore {
 		m := vm.Get(ins.Map).Map
-		vm.Set(ins.KeyResult, array[pos])
+
+		// Key may be optionally set.
+		if ins.KeyResult != "" {
+			vm.Set(ins.KeyResult, array[pos])
+		}
+
 		vm.Set(ins.ValueResult, m[array[pos].Value])
 		vm.Set(ins.Cursor, asttest.NewLiteralNumber(fmt.Sprintf("%d", pos+1)))
 	}

--- a/vm/next_string.go
+++ b/vm/next_string.go
@@ -23,7 +23,11 @@ func (ins *NextString) Execute(_ *int, vm *VM) error {
 	hasMore := pos < len(str)
 	vm.Set(ins.Result, asttest.NewLiteralBool(hasMore))
 	if hasMore {
-		vm.Set(ins.KeyResult, asttest.NewLiteralNumber(fmt.Sprintf("%d", pos)))
+		// Key may be optionally set.
+		if ins.KeyResult != "" {
+			vm.Set(ins.KeyResult, asttest.NewLiteralNumber(fmt.Sprintf("%d", pos)))
+		}
+
 		vm.Set(ins.ValueResult, asttest.NewLiteralChar(str[pos]))
 		vm.Set(ins.Cursor, asttest.NewLiteralNumber(fmt.Sprintf("%d", pos+1)))
 	}


### PR DESCRIPTION
Previously we would allocate a map at the start of the function only if
it was a constructor. Now that map is provided by the VM always, rather
than being allocated sometimes. This makes the instructions simpler, but
also will allow us to inject the state when we call it as a method later
on.

Another important note is that all variables that start with an
uppercase letter will be included in the state (even if it's not a
constructor) everything else (including variable) are considered simple
registers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/ok/54)
<!-- Reviewable:end -->
