### PR TITLE
Only temporary registers are now stored in "registers"

### DIFF
--- a/tests/methods/main.ok
+++ b/tests/methods/main.ok
@@ -1,11 +1,11 @@
 func greeter() greeter {
-    func sayHello(name string) {
+    func SayHello(name string) {
         print("Hi", name)
     }
 }
 
 func main() {
     g = greeter()
-    g.sayHello("Jane")
-    g.sayHello("John")
+    g.SayHello("Jane")
+    g.SayHello("John")
 }

--- a/vm/call.go
+++ b/vm/call.go
@@ -24,7 +24,7 @@ func (ins *Call) Execute(_ *int, vm *VM) error {
 	}
 
 	for i, result := range results {
-		vm.Stack[len(vm.Stack)-2][ins.Results[i]] = vm.Stack[len(vm.Stack)-1][result]
+		vm.set(ins.Results[i], vm.Get(result), 2)
 	}
 
 	vm.Stack = vm.Stack[:len(vm.Stack)-1]

--- a/vm/print_test.go
+++ b/vm/print_test.go
@@ -110,11 +110,12 @@ func TestPrint_Execute(t *testing.T) {
 				{
 					Kind: "Person",
 					Map: map[string]*ast.Literal{
-						"foo": asttest.NewLiteralNumber("123"),
+						"Foo": asttest.NewLiteralNumber("123"),
+						"bar": asttest.NewLiteralNumber("456"),
 					},
 				},
 			},
-			"{\"foo\": 123}\n",
+			"{\"Foo\": 123}\n",
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {


### PR DESCRIPTION
All named variables are now stored in the state, including private
variables. This is to allow us to pass a single instance for the parent
scope coming later.

Since there is now private variables in the state we have to be careful
not to expose them through printing as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/ok/58)
<!-- Reviewable:end -->
