### PR TITLE
Escape characters in strings

### DIFF
--- a/ast/asttest/assert.go
+++ b/ast/asttest/assert.go
@@ -30,6 +30,7 @@ func cmpOptions() cmp.Options {
 		cmpopts.IgnoreFields(ast.Identifier{}, "Pos"),
 		cmpopts.IgnoreFields(ast.If{}, "Pos"),
 		cmpopts.IgnoreFields(ast.In{}, "Pos"),
+		cmpopts.IgnoreFields(ast.Interpolate{}, "Pos"),
 		cmpopts.IgnoreFields(ast.Key{}, "Pos"),
 		cmpopts.IgnoreFields(ast.Literal{}, "Pos"),
 		cmpopts.IgnoreFields(ast.Map{}, "Pos"),

--- a/lexer/tokenize_test.go
+++ b/lexer/tokenize_test.go
@@ -98,12 +98,6 @@ func TestTokenizeString(t *testing.T) {
 				{lexer.TokenEOF, "", false, pos(2)},
 			},
 		},
-		"newline": {
-			str: "\n",
-			expected: []lexer.Token{
-				{lexer.TokenEOF, "", false, pos2(2, 1)},
-			},
-		},
 		"paren-open-close": {
 			str: "()",
 			expected: []lexer.Token{
@@ -725,18 +719,6 @@ func TestTokenizeString(t *testing.T) {
 				{lexer.TokenEOF, "", false, pos(5)},
 			},
 		},
-		"carriage-return": {
-			str: "\r",
-			expected: []lexer.Token{
-				{lexer.TokenEOF, "", false, pos2(2, 1)},
-			},
-		},
-		"tab": {
-			str: "\t",
-			expected: []lexer.Token{
-				{lexer.TokenEOF, "", false, pos(2)},
-			},
-		},
 		"is-end-of-line-1": {
 			str: "a = 1\nprint(",
 			expected: []lexer.Token{
@@ -1142,6 +1124,164 @@ func TestTokenizeString(t *testing.T) {
 				{lexer.TokenIdentifier, "^foo", false, pos(1)},
 				{lexer.TokenEOF, "", false, pos(5)},
 			},
+		},
+		"string-alert-or-bell": {
+			str: `"foo\abar"`,
+			expected: []lexer.Token{
+				{lexer.TokenStringLiteral, "foo\abar", false, pos(1)},
+				{lexer.TokenEOF, "", false, pos(10)},
+			},
+		},
+		"string-backspace": {
+			str: `"foo\bbar"`,
+			expected: []lexer.Token{
+				{lexer.TokenStringLiteral, "foo\bbar", false, pos(1)},
+				{lexer.TokenEOF, "", false, pos(10)},
+			},
+		},
+		"string-form-feed": {
+			str: `"foo\fbar"`,
+			expected: []lexer.Token{
+				{lexer.TokenStringLiteral, "foo\fbar", false, pos(1)},
+				{lexer.TokenEOF, "", false, pos(10)},
+			},
+		},
+		"string-new-line": {
+			str: `"foo\nbar"`,
+			expected: []lexer.Token{
+				{lexer.TokenStringLiteral, "foo\nbar", false, pos(1)},
+				{lexer.TokenEOF, "", false, pos(10)},
+			},
+		},
+		"string-carriage-return": {
+			str: `"foo\rbar"`,
+			expected: []lexer.Token{
+				{lexer.TokenStringLiteral, "foo\rbar", false, pos(1)},
+				{lexer.TokenEOF, "", false, pos(10)},
+			},
+		},
+		"string-horizontal-tab": {
+			str: `"foo\tbar"`,
+			expected: []lexer.Token{
+				{lexer.TokenStringLiteral, "foo\tbar", false, pos(1)},
+				{lexer.TokenEOF, "", false, pos(10)},
+			},
+		},
+		"string-vertical-tab": {
+			str: `"foo\vbar"`,
+			expected: []lexer.Token{
+				{lexer.TokenStringLiteral, "foo\vbar", false, pos(1)},
+				{lexer.TokenEOF, "", false, pos(10)},
+			},
+		},
+		"string-backslash": {
+			str: `"foo\\bar"`,
+			expected: []lexer.Token{
+				{lexer.TokenStringLiteral, "foo\\bar", false, pos(1)},
+				{lexer.TokenEOF, "", false, pos(10)},
+			},
+		},
+		"string-double-quote": {
+			str: `"foo\"bar"`,
+			expected: []lexer.Token{
+				{lexer.TokenStringLiteral, "foo\"bar", false, pos(1)},
+				{lexer.TokenEOF, "", false, pos(10)},
+			},
+		},
+		"string-open-curly": {
+			str: `"foo\{bar"`,
+			expected: []lexer.Token{
+				{lexer.TokenInterpolateStart, "", false, pos(2)},
+				{lexer.TokenStringLiteral, "foo{bar", false, pos(2)},
+				{lexer.TokenInterpolateEnd, "", false, pos(9)},
+				{lexer.TokenEOF, "", false, pos(11)},
+			},
+		},
+		"string-invalid-escape": {
+			str: `"foo\Zbar"`,
+			err: errors.New("a.ok:1:1 invalid escape '\\Z'"),
+		},
+		"string-escape-missing-char": {
+			str: `"foo\"`,
+			err: errors.New("a.ok:1:1 unterminated literal, did not find closing \""),
+		},
+		"char-alert-or-bell": {
+			str: `'\a'`,
+			expected: []lexer.Token{
+				{lexer.TokenCharLiteral, "\a", false, pos(1)},
+				{lexer.TokenEOF, "", false, pos(4)},
+			},
+		},
+		"char-backspace": {
+			str: `'\b'`,
+			expected: []lexer.Token{
+				{lexer.TokenCharLiteral, "\b", false, pos(1)},
+				{lexer.TokenEOF, "", false, pos(4)},
+			},
+		},
+		"char-form-feed": {
+			str: `'\f'`,
+			expected: []lexer.Token{
+				{lexer.TokenCharLiteral, "\f", false, pos(1)},
+				{lexer.TokenEOF, "", false, pos(4)},
+			},
+		},
+		"char-new-line": {
+			str: `'\n'`,
+			expected: []lexer.Token{
+				{lexer.TokenCharLiteral, "\n", false, pos(1)},
+				{lexer.TokenEOF, "", false, pos(4)},
+			},
+		},
+		"char-carriage-return": {
+			str: `'\r'`,
+			expected: []lexer.Token{
+				{lexer.TokenCharLiteral, "\r", false, pos(1)},
+				{lexer.TokenEOF, "", false, pos(4)},
+			},
+		},
+		"char-horizontal-tab": {
+			str: `'\t'`,
+			expected: []lexer.Token{
+				{lexer.TokenCharLiteral, "\t", false, pos(1)},
+				{lexer.TokenEOF, "", false, pos(4)},
+			},
+		},
+		"char-vertical-tab": {
+			str: `'\v'`,
+			expected: []lexer.Token{
+				{lexer.TokenCharLiteral, "\v", false, pos(1)},
+				{lexer.TokenEOF, "", false, pos(4)},
+			},
+		},
+		"char-backslash": {
+			str: `'\\'`,
+			expected: []lexer.Token{
+				{lexer.TokenCharLiteral, "\\", false, pos(1)},
+				{lexer.TokenEOF, "", false, pos(4)},
+			},
+		},
+		"char-double-quote": {
+			str: `'\"'`,
+			expected: []lexer.Token{
+				{lexer.TokenCharLiteral, "\"", false, pos(1)},
+				{lexer.TokenEOF, "", false, pos(4)},
+			},
+		},
+		"char-open-curly": {
+			str: `'{'`,
+			expected: []lexer.Token{
+				{lexer.TokenCharLiteral, "{", false, pos(1)},
+				{lexer.TokenEOF, "", false, pos(4)},
+			},
+		},
+		"char-invalid-escape": {
+			str: `'\Z'`,
+			err: errors.New("a.ok:1:1 invalid escape '\\Z'"),
+		},
+		"char-escape-missing-char": {
+			str: `'\'`,
+			err: errors.New("a.ok:1:1 invalid escape '\\''"),
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {

--- a/lib/lang/escape.okt
+++ b/lib/lang/escape.okt
@@ -1,0 +1,12 @@
+test "escape characters" {
+    // The values are hard to test, but we can check the lengths.
+    assert(len("\a") == 1)
+    assert(len("\b") == 1)
+    assert(len("\f") == 1)
+    assert(len("\n") == 1)
+    assert(len("\r") == 1)
+    assert(len("\t") == 1)
+    assert(len("\v") == 1)
+    assert(len("\{") == 1)
+    assert(len("\"") == 1)
+}

--- a/parser/interpolate_test.go
+++ b/parser/interpolate_test.go
@@ -1,6 +1,7 @@
 package parser_test
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -40,6 +41,30 @@ func TestInterpolate(t *testing.T) {
 					},
 					asttest.NewLiteralString(" there"),
 				},
+			},
+		},
+		"empty-1": {
+			str: `"hi {} there"`,
+			expected: &ast.Interpolate{
+				Parts: []ast.Node{
+					asttest.NewLiteralString("hi "),
+					// The remaining interpolate parts are ignored.
+				},
+			},
+			errs: []error{
+				errors.New("a.ok:1:16 empty interpolation, perhaps missing an escape"),
+			},
+		},
+		"empty-2": {
+			str: `"hi { } there"`,
+			expected: &ast.Interpolate{
+				Parts: []ast.Node{
+					asttest.NewLiteralString("hi "),
+					// The remaining interpolate parts are ignored.
+				},
+			},
+			errs: []error{
+				errors.New("a.ok:1:16 empty interpolation, perhaps missing an escape"),
 			},
 		},
 	} {

--- a/vm/interpolate.go
+++ b/vm/interpolate.go
@@ -94,11 +94,11 @@ func renderLiteral(v *ast.Literal, asJSON bool) string {
 
 		// We do not render function literals. These would almost never be
 		// useful in a JSON output.
-		if kind.IsFunc(v.Map[key].Kind) {
+		element := v.Map[key]
+		if kind.IsFunc(element.Kind) {
 			continue
 		}
 
-		element := v.Map[key]
 		if j > 0 {
 			s += ", "
 		}


### PR DESCRIPTION
All the common escape characters; "\n" (newline), "\t" (tab), etc. They
can be used in strings, chars and datas.

Also fixes a bug where an empty interpolation would cause an infinite
loop in the parser. Now it is reported as an error, you must escape all
"{" characters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/ok/65)
<!-- Reviewable:end -->
