### PR TITLE
Allow glob patterns in "ok asm" arguments

### DIFF
--- a/util/glob.go
+++ b/util/glob.go
@@ -1,0 +1,15 @@
+package util
+
+import (
+	"regexp"
+	"strings"
+)
+
+// MatchesGlob is a very rudimentary implementation of glob matching on strings.
+// Right now it only supports "*" that will match zero or more characters
+// anywhere within the string.
+func MatchesGlob(s, glob string) bool {
+	regex := "^" + strings.ReplaceAll(glob, "*", ".*") + "$"
+
+	return regexp.MustCompile(regex).MatchString(s)
+}

--- a/util/glob_test.go
+++ b/util/glob_test.go
@@ -1,0 +1,37 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchesGlob(t *testing.T) {
+	tests := map[string]struct {
+		s, glob string
+		match   bool
+	}{
+		"1":  {"foo", "foo", true},
+		"2":  {"food", "foo", false},
+		"3":  {"Foo", "foo", false},
+		"4":  {"", "", true},
+		"5":  {"foo", "foo*", true},
+		"6":  {"food", "foo*", true},
+		"7":  {"foo", "*foo", true},
+		"8":  {"aafoo", "*foo", true},
+		"9":  {"foo", "f*oo", true},
+		"10": {"f12oo", "f*oo", true},
+		"11": {"foo", "f**oo", true},
+		"12": {"f12oo", "f**oo", true},
+		"13": {"f12o1o", "f**oo", false},
+		"14": {"f1o2o", "f*o*o", true},
+		"15": {"f1oo", "f*o*o", true},
+		"16": {"foo", "*", true},
+		"17": {"", "*", true},
+	}
+	for testName, tt := range tests {
+		t.Run(testName, func(t *testing.T) {
+			assert.Equal(t, tt.match, MatchesGlob(tt.s, tt.glob))
+		})
+	}
+}


### PR DESCRIPTION
Sometimes it's necessary to see all functions (use "*"), or all
functions with a prefix (use "Log*"). The glob only supports "*"
matching zero or more characters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/ok/66)
<!-- Reviewable:end -->
