### PR TITLE
Fix equality with maps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ vm/lib.go: lib-gen
 
 run-lib-tests:
 	for d in $(shell ls -d lib/*/); do \
-        ./ok test $$d ; \
+        ./ok test $$d || exit 1 ; \
     done
 
 check-doc:

--- a/compiler/array.go
+++ b/compiler/array.go
@@ -8,7 +8,11 @@ import (
 	"github.com/elliotchance/ok/vm"
 )
 
-func compileArray(compiledFunc *vm.CompiledFunc, n *ast.Array, file *Compiled) (vm.Register, string, error) {
+func compileArray(
+	compiledFunc *vm.CompiledFunc,
+	n *ast.Array,
+	file *Compiled,
+) (vm.Register, string, error) {
 	if len(n.Elements) == 0 && n.Kind == "" {
 		err := fmt.Errorf("%s empty array needs to specify a type",
 			n.Position())

--- a/compiler/binary.go
+++ b/compiler/binary.go
@@ -69,25 +69,49 @@ func getBinaryInstruction(op string, left, right, result vm.Register) (vm.Instru
 	case "bool or bool":
 		return &vm.Or{Left: left, Right: right, Result: result}, "bool"
 
-	case "bool == bool", "char == char", "data == data", "string == string",
+	case "bool == bool",
+		"char == char",
+		"data == data",
+		"string == string",
+
 		// TODO(elliot): These below is not documented in the language spec.
+		// arrays
 		"[]bool == []bool",
 		"[]char == []char",
 		"[]data == []data",
 		"[]number == []number",
-		"[]string == []string":
+		"[]string == []string",
+
+		// maps
+		"{}bool == {}bool",
+		"{}char == {}char",
+		"{}data == {}data",
+		"{}number == {}number",
+		"{}string == {}string":
 		return &vm.Equal{Left: left, Right: right, Result: result}, "bool"
 
 	case "number == number":
 		return &vm.EqualNumber{Left: left, Right: right, Result: result}, "bool"
 
-	case "bool != bool", "char != char", "data != data", "string != string",
+	case "bool != bool",
+		"char != char",
+		"data != data",
+		"string != string",
+
 		// TODO(elliot): These below is not documented in the language spec.
+		// arrays
 		"[]bool != []bool",
 		"[]char != []char",
 		"[]data != []data",
 		"[]number != []number",
-		"[]string != []string":
+		"[]string != []string",
+
+		// maps
+		"{}bool != {}bool",
+		"{}char != {}char",
+		"{}data != {}data",
+		"{}number != {}number",
+		"{}string != {}string":
 		return &vm.NotEqual{Left: left, Right: right, Result: result}, "bool"
 
 	case "number != number":
@@ -116,7 +140,6 @@ func getBinaryInstruction(op string, left, right, result vm.Register) (vm.Instru
 
 	case "string <= string":
 		return &vm.LessThanEqualString{Left: left, Right: right, Result: result}, "bool"
-
 	}
 
 	return nil, ""

--- a/compiler/expr.go
+++ b/compiler/expr.go
@@ -60,13 +60,12 @@ func compileExpr(compiledFunc *vm.CompiledFunc, expr ast.Node, file *Compiled) (
 		return []vm.Register{returns}, []string{kind}, nil
 
 	case *ast.Map:
-		returns, err := compileMap(compiledFunc, e, file)
+		returns, kind, err := compileMap(compiledFunc, e, file)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		// TODO(elliot): Doesn't return type.
-		return []vm.Register{returns}, []string{"{}"}, nil
+		return []vm.Register{returns}, []string{kind}, nil
 
 	case *ast.Call:
 		results, resultKinds, err := compileCall(compiledFunc, e, file)

--- a/compiler/for_test.go
+++ b/compiler/for_test.go
@@ -211,7 +211,7 @@ func TestFor(t *testing.T) {
 					Value:        asttest.NewLiteralNumber("2"),
 				},
 				&vm.MapAlloc{
-					Kind:   "{}any",
+					Kind:   "{}number",
 					Size:   "1",
 					Result: "2",
 				},
@@ -296,7 +296,7 @@ func TestFor(t *testing.T) {
 					Value:        asttest.NewLiteralNumber("2"),
 				},
 				&vm.MapAlloc{
-					Kind:   "{}any",
+					Kind:   "{}number",
 					Size:   "1",
 					Result: "2",
 				},

--- a/compiler/key_test.go
+++ b/compiler/key_test.go
@@ -130,7 +130,7 @@ func TestKey(t *testing.T) {
 					Value:        asttest.NewLiteralNumber("2"),
 				},
 				&vm.MapAlloc{
-					Kind:   "{}any",
+					Kind:   "{}number",
 					Size:   "1",
 					Result: "2",
 				},
@@ -218,7 +218,7 @@ func TestKey(t *testing.T) {
 					Value:        asttest.NewLiteralNumber("2"),
 				},
 				&vm.MapAlloc{
-					Kind:   "{}any",
+					Kind:   "{}number",
 					Size:   "1",
 					Result: "2",
 				},
@@ -402,7 +402,7 @@ func TestKey(t *testing.T) {
 					Value:        asttest.NewLiteralNumber("2"),
 				},
 				&vm.MapAlloc{
-					Kind:   "{}any",
+					Kind:   "{}number",
 					Size:   "1",
 					Result: "2",
 				},

--- a/compiler/map.go
+++ b/compiler/map.go
@@ -8,7 +8,11 @@ import (
 	"github.com/elliotchance/ok/vm"
 )
 
-func compileMap(compiledFunc *vm.CompiledFunc, n *ast.Map, file *Compiled) (vm.Register, error) {
+func compileMap(
+	compiledFunc *vm.CompiledFunc,
+	n *ast.Map,
+	file *Compiled,
+) (vm.Register, string, error) {
 	// TODO(elliot): Check type is valid for the map.
 	// TODO(elliot): Maps with duplicate keys should be an error.
 
@@ -19,23 +23,25 @@ func compileMap(compiledFunc *vm.CompiledFunc, n *ast.Map, file *Compiled) (vm.R
 	})
 
 	mapRegister := compiledFunc.NextRegister()
-	compiledFunc.Append(&vm.MapAlloc{
-		// TODO(elliot): This needs to be derived from the actual type.
-		Kind: "{}any",
-
+	mapAlloc := &vm.MapAlloc{
+		Kind:   n.Kind,
 		Size:   sizeRegister,
 		Result: mapRegister,
-	})
+	}
+	compiledFunc.Append(mapAlloc)
 
 	for _, element := range n.Elements {
 		// TODO(elliot): Check keyKind is string.
 		keyRegisters, _, err := compileExpr(compiledFunc, element.Key, file)
 		if err != nil {
-			return "", err
+			return "", "", err
 		}
 
 		// TODO(elliot): Check value is the right type for map.
-		valueRegisters, _, _ := compileExpr(compiledFunc, element.Value, file)
+		valueRegisters, valueKind, _ := compileExpr(compiledFunc, element.Value, file)
+		if mapAlloc.Kind == "" {
+			mapAlloc.Kind = "{}" + valueKind[0]
+		}
 
 		compiledFunc.Append(&vm.MapSet{
 			Map:   mapRegister,
@@ -44,5 +50,5 @@ func compileMap(compiledFunc *vm.CompiledFunc, n *ast.Map, file *Compiled) (vm.R
 		})
 	}
 
-	return mapRegister, nil
+	return mapRegister, mapAlloc.Kind, nil
 }

--- a/compiler/map_test.go
+++ b/compiler/map_test.go
@@ -28,7 +28,7 @@ func TestMap(t *testing.T) {
 					Value:        asttest.NewLiteralNumber("0"),
 				},
 				&vm.MapAlloc{
-					Kind:   "{}any",
+					Kind:   "{}number",
 					Size:   "1",
 					Result: "2",
 				},
@@ -58,7 +58,7 @@ func TestMap(t *testing.T) {
 					Value:        asttest.NewLiteralNumber("3"),
 				},
 				&vm.MapAlloc{
-					Kind:   "{}any",
+					Kind:   "{}number",
 					Size:   "1",
 					Result: "2",
 				},
@@ -132,7 +132,7 @@ func TestMap(t *testing.T) {
 					Value:        asttest.NewLiteralNumber("1"),
 				},
 				&vm.MapAlloc{
-					Kind:   "{}any",
+					Kind:   "{}number",
 					Size:   "1",
 					Result: "2",
 				},

--- a/lib/lang/equal.okt
+++ b/lib/lang/equal.okt
@@ -1,4 +1,4 @@
-test "==" {
+test "'==' for literals" {
     assert(true == true)
     assert(false == false)
 
@@ -19,7 +19,9 @@ test "==" {
     assert(`` == ``)
     assert(`foo` == `foo`)
     assert(`😃foo` == `😃foo`)
+}
 
+test "'==' for arrays" {
     assert([]bool [] == []bool [])
     assert([]bool [true] == []bool [true])
     assert([]bool [true, false] == []bool [true, false])
@@ -39,4 +41,26 @@ test "==" {
     assert([]string [] == []string [])
     assert([]string ["a"] == []string ["a"])
     assert([]string ["a", "😃foo"] == []string ["a", "😃foo"])
+}
+
+test "'==' for maps" {
+    assert({}bool {} == {}bool {})
+    assert({}bool {"a": true} == {}bool {"a": true})
+    assert({}bool {"a": true, "b": false} == {}bool {"b": false, "a": true})
+
+    assert({}char {} == {}char {})
+    assert({}char {"foo": 'a'} == {}char {"foo": 'a'})
+    assert({}char {"foo": 'a', "bar": '😃'} == {}char {"bar": '😃', "foo": 'a'})
+
+    assert({}data {} == {}data {})
+    assert({}data {"foo": `a`} == {}data {"foo": `a`})
+    assert({}data {"foo": `a`, "bar": `😃`} == {}data {"bar": `😃`, "foo": `a`})
+
+    assert({}number {} == {}number {})
+    assert({}number {"foo": 1.23} == {}number {"foo": 1.23})
+    assert({}number {"foo": 1.23, "bar": 4.56} == {}number {"bar": 4.56, "foo": 1.23})
+
+    assert({}string {} == {}string {})
+    assert({}string {"foo": "a"} == {}string {"foo": "a"})
+    assert({}string {"foo": "a", "bar": "😃foo"} == {}string {"bar": "😃foo", "foo": "a"})
 }

--- a/lib/lang/not-equal.okt
+++ b/lib/lang/not-equal.okt
@@ -1,4 +1,4 @@
-test "!=" {
+test "'!=' for literals" {
     assert(true != false)
     assert(false != true)
 
@@ -19,7 +19,9 @@ test "!=" {
     assert(`` != `b`)
     assert(`foo` != `bar`)
     assert(`😃foo` != `😃bar`)
+}
 
+test "'!=' for arrays" {
     assert([]bool [] != []bool [true])
     assert([]bool [true] != []bool [false])
     assert([]bool [true, false] != []bool [true, true])
@@ -39,4 +41,27 @@ test "!=" {
     assert([]string [] != []string ["a"])
     assert([]string ["a"] != []string ["b"])
     assert([]string ["a", "😃foo"] != []string ["a", "😃bar"])
+}
+
+test "'!=' for maps" {
+    assert({}bool {} != {}bool {"a": true})
+    assert({}bool {"a": true} != {}bool {"a": false})
+    assert({}bool {"a": true, "b": false} != {}bool {"a": false, "b": true})
+    assert({}bool {"a": true, "b": false} != {}bool {"a": false, "b": true})
+
+    assert({}char {} != {}char {"foo": 'a'})
+    assert({}char {"foo": 'a'} != {}char {"foo": 'b'})
+    assert({}char {"foo": 'a', "bar": '😃'} != {}char {"foo": '😃', "bar": 'a'})
+
+    assert({}data {} != {}data {"foo": `a`})
+    assert({}data {"foo": `a`} != {}data {"foo": `b`})
+    assert({}data {"foo": `a`, "bar": `😃`} != {}data {"foo": `😃`, "bar": `a`})
+
+    assert({}number {} != {}number {"foo": 1.23})
+    assert({}number {"foo": 1.23} != {}number {"foo": 2.23})
+    assert({}number {"foo": 1.23, "bar": 4.56} != {}number {"foo": 4.56, "bar": 1.23})
+
+    assert({}string {} != {}string {"foo": "a"})
+    assert({}string {"foo": "a"} != {}string {"foo": "b"})
+    assert({}string {"foo": "a", "bar": "😃foo"} != {}string {"foo": "😃foo", "bar": "a"})
 }

--- a/vm/equal.go
+++ b/vm/equal.go
@@ -71,6 +71,31 @@ func compareValue(a, b *ast.Literal) bool {
 
 		return false
 
+	case kind.IsMap(a.Kind):
+		if len(a.Map) != len(b.Map) {
+			return false
+		}
+
+		keys := make(map[string]struct{})
+		for key := range a.Map {
+			keys[key] = struct{}{}
+		}
+		for key := range b.Map {
+			keys[key] = struct{}{}
+		}
+
+		if len(keys) != len(a.Map) {
+			return false
+		}
+
+		for k, v := range a.Map {
+			if !compareValue(v, b.Map[k]) {
+				return false
+			}
+		}
+
+		return true
+
 	case a.Kind == "number":
 		return numbersAreEqual(a, b)
 


### PR DESCRIPTION
Maps of the same type (ie. {}string == {}string) are now allowed to be
compared.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/ok/69)
<!-- Reviewable:end -->
