### PR TITLE
Remove code coverage from CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ clean:
 	rm -f ok
 	rm -f coverage.txt
 
-ci: clean test-fmt vet test-coverage run-tests check-doc check-stdlib
+ci: clean test-fmt vet test run-tests check-doc check-stdlib
 
 test:
 	go test -race ./...


### PR DESCRIPTION
Many of the tests are now in the form of actual ok programs. So they do
not get included in the overall coverage. Apart from the current code
coverage percentage from being inaccurate it's always showing most PRs
as failing because the code coverage amount is dropping.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/ok/73)
<!-- Reviewable:end -->
