### PR TITLE
Added verbose and filter for "ok test"

### DIFF
--- a/vm/vm.go
+++ b/vm/vm.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"runtime/debug"
 
 	"github.com/elliotchance/ok/ast"
@@ -86,8 +87,16 @@ func (vm *VM) Run() error {
 }
 
 // Run will run the tests only.
-func (vm *VM) RunTests() error {
+func (vm *VM) RunTests(verbose bool, filter *regexp.Regexp) error {
 	for _, t := range vm.tests {
+		if !filter.MatchString(t.TestName) {
+			continue
+		}
+
+		if verbose {
+			fmt.Println("#", t.TestName)
+		}
+
 		vm.CurrentTestPassed = true
 		err := vm.runTest(t.TestName, t.Instructions, map[string]*ast.Literal{})
 		if err != nil {


### PR DESCRIPTION
- "-v" will print the test names (eg. "# TrimLeft") before each test.
- "-f" can be used with a regexp to filter tests by name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/ok/76)
<!-- Reviewable:end -->
