### PR TITLE
Added code coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ clean:
 	rm -f ok
 	rm -f coverage.txt
 
-ci: clean test-fmt vet test run-tests check-doc check-stdlib
+ci: clean test-fmt vet test-coverage run-tests check-doc check-stdlib
 
 test:
 	go test -race ./...

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
This was previously added then removed because it was causing the builds
to fail when the coverage dropped. Now we are at a point where we should
start tracking it again. The code coverage is now information only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/ok/82)
<!-- Reviewable:end -->
