### PR TITLE
Remove redundant interfaces structures

### DIFF
--- a/cmd/run/main.go
+++ b/cmd/run/main.go
@@ -33,7 +33,7 @@ func (*Command) Run(args []string) {
 	for _, arg := range args {
 		packageName := util.PackageNameFromPath(okPath, arg)
 
-		m := vm.NewVM(nil, nil, nil, "no-package")
+		m := vm.NewVM("no-package")
 		_, errs := compiler.Compile(okPath, packageName, false)
 		util.CheckErrorsWithExit(errs)
 

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -51,7 +51,7 @@ func (c *Command) Run(args []string) {
 		_, errs := compiler.Compile(okPath, packageName, true)
 		util.CheckErrorsWithExit(errs)
 
-		m := vm.NewVM(nil, nil, nil, "no-package")
+		m := vm.NewVM("no-package")
 		startTime := time.Now()
 		check(m.LoadPackage("", packageName))
 		err := m.RunTests(c.Verbose, regexp.MustCompile(c.Filter))

--- a/compiler/call.go
+++ b/compiler/call.go
@@ -77,10 +77,17 @@ func compileCall(
 		returnRegisters = append(returnRegisters, compiledFunc.NextRegister())
 	}
 
+	objType := types.Any
+	if len(fnType[0].Returns) == 1 &&
+		fnType[0].Returns[0].Kind == types.KindResolvedInterface {
+		objType = fnType[0].Returns[0]
+	}
+
 	ins := &vm.Call{
 		FunctionName: fmt.Sprintf("*%s", string(fnResult[0])),
 		Arguments:    argResults,
 		Results:      returnRegisters,
+		Type:         objType,
 	}
 
 	compiledFunc.Append(ins)

--- a/compiler/compile.go
+++ b/compiler/compile.go
@@ -49,7 +49,7 @@ func Compile(rootPath, pkgPath string, includeTests bool) (*vm.File, []error) {
 		funcs[fnName] = fn
 	}
 
-	okcFile, err := compile(funcs, p.Tests(), p.Interfaces, p.Constants, imports)
+	okcFile, err := compile(funcs, p.Tests(), p.Constants, imports)
 	if err != nil {
 		return nil, []error{err}
 	}

--- a/compiler/error_scope.go
+++ b/compiler/error_scope.go
@@ -37,7 +37,7 @@ func compileErrorScope(
 	// Each of the On clauses.
 	for _, on := range n.On {
 		compiledFunc.Append(&vm.On{
-			Type: file.ResolveType(on.Type),
+			Type: on.Type,
 		})
 
 		// Provide the err variable. The runtime value will be provided by the

--- a/compiler/error_scope_test.go
+++ b/compiler/error_scope_test.go
@@ -62,7 +62,7 @@ func TestErrorScope(t *testing.T) {
 					},
 					On: []*ast.On{
 						{
-							Type: types.NewUnresolvedInterface("SomeError"),
+							Type: types.NewInterface("SomeError", nil),
 						},
 					},
 				},
@@ -95,10 +95,10 @@ func TestErrorScope(t *testing.T) {
 					},
 					On: []*ast.On{
 						{
-							Type: types.NewUnresolvedInterface("SomeError"),
+							Type: types.NewInterface("SomeError", nil),
 						},
 						{
-							Type: types.NewUnresolvedInterface("SomethingElse"),
+							Type: types.NewInterface("SomethingElse", nil),
 							Statements: []ast.Node{
 								&ast.Call{
 									Expr: &ast.Identifier{Name: "print"},

--- a/compiler/file.go
+++ b/compiler/file.go
@@ -9,16 +9,14 @@ import (
 func compile(
 	funcs map[string]*ast.Func,
 	tests []*ast.Test,
-	interfaces map[string]map[string]*types.Type,
 	constants map[string]*ast.Literal,
 	imports map[string]map[string]*types.Type,
 ) (*vm.File, error) {
 	file := &vm.File{
-		Funcs:      map[string]*vm.CompiledFunc{},
-		FuncDefs:   funcs,
-		Interfaces: interfaces,
-		Constants:  constants,
-		Imports:    imports,
+		Funcs:     map[string]*vm.CompiledFunc{},
+		FuncDefs:  funcs,
+		Constants: constants,
+		Imports:   imports,
 	}
 
 	for name, fn := range funcs {

--- a/compiler/func.go
+++ b/compiler/func.go
@@ -10,9 +10,8 @@ import (
 // number of instructions returned may be zero.
 func CompileFunc(fn *ast.Func, file *vm.File) (*vm.CompiledFunc, error) {
 	compiled := &vm.CompiledFunc{
-		Variables:  map[string]*types.Type{},
-		Interfaces: file.Interfaces,
-		Type:       fn.Type(),
+		Variables: map[string]*types.Type{},
+		Type:      fn.Type(),
 	}
 
 	// All variables in a function are stored internally as a map right now. So

--- a/compiler/key.go
+++ b/compiler/key.go
@@ -104,18 +104,24 @@ func compileKey(
 			Result: resultRegister,
 		})
 
-		if iface, ok := file.Interfaces[arrayOrMapKind[0].Name]; ok {
-			ty := iface[n.Key.(*ast.Identifier).Name]
+		if fn, ok := file.FuncDefs[arrayOrMapKind[0].Name]; ok {
+			if !fn.IsConstructor() {
+				return "", nil, fmt.Errorf("%s %s is not an interface",
+					n.Position(), fn.Name)
+			}
 
-			return resultRegister, ty, nil
+			return resultRegister, fn.Returns[0], nil
 		}
 
 		parts := strings.Split(arrayOrMapKind[0].Name, ".")
 		if len(parts) == 2 {
-			if iface, ok := vm.Packages[parts[0]].Interfaces[parts[1]]; ok {
-				ty := iface[n.Key.(*ast.Identifier).Name]
+			if fn, ok := vm.Packages[parts[0]].FuncDefs[parts[1]]; ok {
+				if !fn.IsConstructor() {
+					return "", nil, fmt.Errorf("%s %s is not an interface",
+						n.Position(), fn.Name)
+				}
 
-				return resultRegister, ty, nil
+				return resultRegister, fn.Returns[0], nil
 			}
 		}
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/lexer"
-	"github.com/elliotchance/ok/types"
 	"github.com/pkg/errors"
 )
 
@@ -17,7 +16,6 @@ type Parser struct {
 	finalizers       map[string][]*ast.Finally
 	functionNames    []string
 	anonFunctionName int
-	Interfaces       map[string]map[string]*types.Type
 	imports          map[string]string
 	comments         []*ast.Comment
 
@@ -100,7 +98,6 @@ func NewParser() *Parser {
 	return &Parser{
 		finalizers: map[string][]*ast.Finally{},
 		Constants:  map[string]*ast.Literal{},
-		Interfaces: map[string]map[string]*types.Type{},
 		imports:    map[string]string{},
 		funcs:      map[string]*ast.Func{},
 	}

--- a/parser/types.go
+++ b/parser/types.go
@@ -2,17 +2,34 @@ package parser
 
 import (
 	"fmt"
+
+	"github.com/elliotchance/ok/types"
 )
 
 func (parser *Parser) resolveInterfaces() error {
 	for _, fn := range parser.funcs {
-		if fn.IsConstructor() {
-			ty, err := fn.Interface()
-			if err != nil {
-				return fmt.Errorf("%v %s", fn.Position(), err)
-			}
+		// Argument types
+		for _, arg := range fn.Arguments {
+			if arg.Type.Kind == types.KindUnresolvedInterface {
+				ty, err := parser.funcs[arg.Type.Name].Interface()
+				if err != nil {
+					return fmt.Errorf("%v %s", fn.Position(), err)
+				}
 
-			parser.Interfaces[fn.Name] = ty
+				arg.Type = types.NewInterface(arg.Type.Name, ty)
+			}
+		}
+
+		// Return types
+		for i, ret := range fn.Returns {
+			if ret.Kind == types.KindUnresolvedInterface {
+				ty, err := parser.funcs[ret.Name].Interface()
+				if err != nil {
+					return fmt.Errorf("%v %s", fn.Position(), err)
+				}
+
+				fn.Returns[i] = types.NewInterface(ret.Name, ty)
+			}
 		}
 	}
 

--- a/vm/call.go
+++ b/vm/call.go
@@ -12,6 +12,10 @@ type Call struct {
 	FunctionName string
 	Arguments    Registers
 	Results      Registers
+
+	// Type is the resolved interface when calling constructors. In any other
+	// case this should be types.Any.
+	Type *types.Type
 }
 
 // Execute implements the Instruction interface for the VM.
@@ -25,8 +29,7 @@ func (ins *Call) Execute(_ *int, vm *VM) error {
 		parentScope = funcLit.Map
 	}
 
-	results, err := vm.call(funcName, ins.Arguments, parentScope,
-		types.TypeFromString(funcName))
+	results, err := vm.call(funcName, ins.Arguments, parentScope, ins.Type)
 	if err != nil {
 		return err
 	}

--- a/vm/dynamic_call.go
+++ b/vm/dynamic_call.go
@@ -39,6 +39,10 @@ func (ins *DynamicCall) Execute(_ *int, vm *VM) error {
 		FunctionName: "*" + string(ins.Variable),
 		Arguments:    args,
 		Results:      results,
+
+		// TODO(elliot): This should be the correct return type, otherwise the
+		//  reflect won't work.
+		Type: types.Any,
 	}
 
 	err := realCall.Execute(nil, vm)

--- a/vm/func.go
+++ b/vm/func.go
@@ -12,7 +12,6 @@ type CompiledFunc struct {
 	Registers    int
 	Variables    map[string]*types.Type // name: type
 	Finally      [][]Instruction
-	Interfaces   map[string]map[string]*types.Type
 	Type         *types.Type
 }
 

--- a/vm/interface.go
+++ b/vm/interface.go
@@ -14,7 +14,7 @@ type Interface struct {
 
 // Execute implements the Instruction interface for the VM.
 func (ins *Interface) Execute(_ *int, vm *VM) error {
-	i := util.Interface(vm.Interfaces[vm.Get(ins.Value).Kind.Name])
+	i := util.Interface(vm.Get(ins.Value).Kind.Properties)
 	vm.Set(ins.Result, asttest.NewLiteralString(i))
 
 	return nil

--- a/vm/lib.go
+++ b/vm/lib.go
@@ -19,13 +19,6 @@ func init() {
 							Kind: 7,
 						},
 					},
-					Interfaces: map[string]map[string]*types.Type{
-						"Error": map[string]*types.Type{
-							"Error": &types.Type{
-								Kind: 7,
-							},
-						},
-					},
 				},
 			},
 			FuncDefs: map[string]*ast.Func{
@@ -38,17 +31,16 @@ func init() {
 					},
 					Returns: []*types.Type{
 						&types.Type{
+							Kind: 1,
 							Name: "Error",
+							Properties: map[string]*types.Type{
+								"Error": &types.Type{
+									Kind: 7,
+								},
+							},
 						},
 					},
 					Pos: "lib/error/error.ok:2:1",
-				},
-			},
-			Interfaces: map[string]map[string]*types.Type{
-				"Error": map[string]*types.Type{
-					"Error": &types.Type{
-						Kind: 7,
-					},
 				},
 			},
 			Constants: nil,
@@ -77,7 +69,6 @@ func init() {
 							Kind: 6,
 						},
 					},
-					Interfaces: nil,
 				},
 				"Cbrt": &CompiledFunc{
 					Arguments: []string{"x"},
@@ -98,7 +89,6 @@ func init() {
 							Kind: 6,
 						},
 					},
-					Interfaces: nil,
 				},
 				"Ceil": &CompiledFunc{
 					Arguments: []string{"x"},
@@ -137,7 +127,6 @@ func init() {
 							Kind: 6,
 						},
 					},
-					Interfaces: nil,
 				},
 				"Exp": &CompiledFunc{
 					Arguments: []string{"x"},
@@ -158,7 +147,6 @@ func init() {
 							Kind: 6,
 						},
 					},
-					Interfaces: nil,
 				},
 				"Floor": &CompiledFunc{
 					Arguments: []string{"x"},
@@ -197,7 +185,6 @@ func init() {
 							Kind: 6,
 						},
 					},
-					Interfaces: nil,
 				},
 				"Log10": &CompiledFunc{
 					Arguments: []string{"x"},
@@ -216,7 +203,6 @@ func init() {
 							Kind: 6,
 						},
 					},
-					Interfaces: nil,
 				},
 				"LogE": &CompiledFunc{
 					Arguments: []string{"x"},
@@ -230,7 +216,6 @@ func init() {
 							Kind: 6,
 						},
 					},
-					Interfaces: nil,
 				},
 				"Pow": &CompiledFunc{
 					Arguments: []string{"base", "power"},
@@ -247,7 +232,6 @@ func init() {
 							Kind: 6,
 						},
 					},
-					Interfaces: nil,
 				},
 				"Round": &CompiledFunc{
 					Arguments: []string{"x", "prec"},
@@ -298,7 +282,6 @@ func init() {
 							Kind: 6,
 						},
 					},
-					Interfaces: nil,
 				},
 				"Sqrt": &CompiledFunc{
 					Arguments: []string{"x"},
@@ -315,7 +298,6 @@ func init() {
 							Kind: 6,
 						},
 					},
-					Interfaces: nil,
 				},
 			},
 			FuncDefs: map[string]*ast.Func{
@@ -466,7 +448,6 @@ func init() {
 					Pos: "lib/math/powers.ok:15:1",
 				},
 			},
-			Interfaces: nil,
 			Constants: map[string]*ast.Literal{
 				"E": &ast.Literal{&types.Type{
 					Kind: 6,
@@ -518,7 +499,6 @@ func init() {
 							Kind: 2,
 						},
 					},
-					Interfaces: nil,
 				},
 				"Get": &CompiledFunc{
 					Arguments: []string{"obj", "prop"},
@@ -535,7 +515,6 @@ func init() {
 							Kind: 2,
 						},
 					},
-					Interfaces: nil,
 				},
 				"Interface": &CompiledFunc{
 					Arguments: []string{"value"},
@@ -549,7 +528,6 @@ func init() {
 							Kind: 2,
 						},
 					},
-					Interfaces: nil,
 				},
 				"Kind": &CompiledFunc{
 					Arguments: []string{"value"},
@@ -567,7 +545,9 @@ func init() {
 								},
 							},
 						}, "Type", nil, nil, ""}, ""},
-						&Call{"*2", Registers{"value"}, Registers{"3"}},
+						&Call{"*2", Registers{"value"}, Registers{"3"}, &types.Type{
+							Kind: 2,
+						}},
 						&Assign{"type", nil, "3"},
 						&Assign{"4", &ast.Literal{&types.Type{
 							Kind: 7,
@@ -588,7 +568,9 @@ func init() {
 								},
 							},
 						}, "hasPrefix", nil, nil, ""}, ""},
-						&Call{"*5", Registers{"type", "4"}, Registers{"6"}},
+						&Call{"*5", Registers{"type", "4"}, Registers{"6"}, &types.Type{
+							Kind: 2,
+						}},
 						&JumpUnless{"6", 9},
 						&Assign{"7", &ast.Literal{&types.Type{
 							Kind: 7,
@@ -615,7 +597,9 @@ func init() {
 								},
 							},
 						}, "hasPrefix", nil, nil, ""}, ""},
-						&Call{"*10", Registers{"type", "8"}, Registers{"11"}},
+						&Call{"*10", Registers{"type", "8"}, Registers{"11"}, &types.Type{
+							Kind: 2,
+						}},
 						&JumpUnless{"11", 17},
 						&Assign{"12", &ast.Literal{&types.Type{
 							Kind: 7,
@@ -641,7 +625,9 @@ func init() {
 								},
 							},
 						}, "hasPrefix", nil, nil, ""}, ""},
-						&Call{"*14", Registers{"type", "13"}, Registers{"15"}},
+						&Call{"*14", Registers{"type", "13"}, Registers{"15"}, &types.Type{
+							Kind: 2,
+						}},
 						&JumpUnless{"15", 24},
 						&Assign{"16", &ast.Literal{&types.Type{
 							Kind: 7,
@@ -659,7 +645,6 @@ func init() {
 							Kind: 2,
 						},
 					},
-					Interfaces: nil,
 				},
 				"Len": &CompiledFunc{
 					Arguments: []string{"value"},
@@ -673,7 +658,6 @@ func init() {
 							Kind: 2,
 						},
 					},
-					Interfaces: nil,
 				},
 				"Properties": &CompiledFunc{
 					Arguments: []string{"obj"},
@@ -687,7 +671,6 @@ func init() {
 							Kind: 2,
 						},
 					},
-					Interfaces: nil,
 				},
 				"Set": &CompiledFunc{
 					Arguments: []string{"obj", "prop", "value"},
@@ -707,7 +690,6 @@ func init() {
 							Kind: 2,
 						},
 					},
-					Interfaces: nil,
 				},
 				"Type": &CompiledFunc{
 					Arguments: []string{"value"},
@@ -721,7 +703,6 @@ func init() {
 							Kind: 2,
 						},
 					},
-					Interfaces: nil,
 				},
 				"hasPrefix": &CompiledFunc{
 					Arguments: []string{"s", "prefix"},
@@ -771,7 +752,6 @@ func init() {
 							Kind: 7,
 						},
 					},
-					Interfaces: nil,
 				},
 			},
 			FuncDefs: map[string]*ast.Func{
@@ -926,8 +906,7 @@ func init() {
 					Pos: "lib/reflect/strings.ok:4:1",
 				},
 			},
-			Interfaces: nil,
-			Constants:  nil,
+			Constants: nil,
 		},
 		"strings": &File{
 			Imports: nil,
@@ -951,7 +930,9 @@ func init() {
 								},
 							},
 						}, "Index", nil, nil, ""}, ""},
-						&Call{"*3", Registers{"s", "substr"}, Registers{"4"}},
+						&Call{"*3", Registers{"s", "substr"}, Registers{"4"}, &types.Type{
+							Kind: 2,
+						}},
 						&Assign{"5", &ast.Literal{&types.Type{
 							Kind: 6,
 						}, "-1", nil, nil, "lib/strings/contains.ok:3:32"}, ""},
@@ -967,7 +948,6 @@ func init() {
 							Kind: 7,
 						},
 					},
-					Interfaces: nil,
 				},
 				"HasPrefix": &CompiledFunc{
 					Arguments: []string{"s", "prefix"},
@@ -1017,7 +997,6 @@ func init() {
 							Kind: 7,
 						},
 					},
-					Interfaces: nil,
 				},
 				"HasSuffix": &CompiledFunc{
 					Arguments: []string{"s", "suffix"},
@@ -1084,7 +1063,6 @@ func init() {
 							Kind: 7,
 						},
 					},
-					Interfaces: nil,
 				},
 				"Index": &CompiledFunc{
 					Arguments: []string{"s", "substr"},
@@ -1111,7 +1089,9 @@ func init() {
 								},
 							},
 						}, "IndexAfter", nil, nil, ""}, ""},
-						&Call{"*4", Registers{"s", "substr", "3"}, Registers{"5"}},
+						&Call{"*4", Registers{"s", "substr", "3"}, Registers{"5"}, &types.Type{
+							Kind: 2,
+						}},
 						&Return{Registers{"5"}},
 					},
 					Registers: 5,
@@ -1123,7 +1103,6 @@ func init() {
 							Kind: 7,
 						},
 					},
-					Interfaces: nil,
 				},
 				"IndexAfter": &CompiledFunc{
 					Arguments: []string{"s", "substr", "offset"},
@@ -1147,7 +1126,9 @@ func init() {
 								},
 							},
 						}, "max", nil, nil, ""}, ""},
-						&Call{"*5", Registers{"offset", "4"}, Registers{"6"}},
+						&Call{"*5", Registers{"offset", "4"}, Registers{"6"}, &types.Type{
+							Kind: 2,
+						}},
 						&Assign{"offset", nil, "6"},
 						&Assign{"7", &ast.Literal{&types.Type{
 							Kind: 6,
@@ -1218,7 +1199,6 @@ func init() {
 							Kind: 7,
 						},
 					},
-					Interfaces: nil,
 				},
 				"Join": &CompiledFunc{
 					Arguments: []string{"strings", "glue"},
@@ -1263,7 +1243,6 @@ func init() {
 							},
 						},
 					},
-					Interfaces: nil,
 				},
 				"LastIndex": &CompiledFunc{
 					Arguments: []string{"s", "substr"},
@@ -1281,7 +1260,9 @@ func init() {
 								},
 							},
 						}, "Reverse", nil, nil, ""}, ""},
-						&Call{"*3", Registers{"s"}, Registers{"4"}},
+						&Call{"*3", Registers{"s"}, Registers{"4"}, &types.Type{
+							Kind: 2,
+						}},
 						&Assign{"5", &ast.Literal{&types.Type{
 							Kind: 10,
 							Arguments: []*types.Type{
@@ -1295,7 +1276,9 @@ func init() {
 								},
 							},
 						}, "Reverse", nil, nil, ""}, ""},
-						&Call{"*5", Registers{"substr"}, Registers{"6"}},
+						&Call{"*5", Registers{"substr"}, Registers{"6"}, &types.Type{
+							Kind: 2,
+						}},
 						&Assign{"7", &ast.Literal{&types.Type{
 							Kind: 10,
 							Arguments: []*types.Type{
@@ -1312,7 +1295,9 @@ func init() {
 								},
 							},
 						}, "Index", nil, nil, ""}, ""},
-						&Call{"*7", Registers{"4", "6"}, Registers{"8"}},
+						&Call{"*7", Registers{"4", "6"}, Registers{"8"}, &types.Type{
+							Kind: 2,
+						}},
 						&Assign{"index", nil, "8"},
 						&Assign{"9", &ast.Literal{&types.Type{
 							Kind: 6,
@@ -1341,7 +1326,6 @@ func init() {
 							Kind: 7,
 						},
 					},
-					Interfaces: nil,
 				},
 				"LastIndexBefore": &CompiledFunc{
 					Arguments: []string{"s", "substr", "offset"},
@@ -1364,7 +1348,9 @@ func init() {
 								},
 							},
 						}, "min", nil, nil, ""}, ""},
-						&Call{"*6", Registers{"offset", "5"}, Registers{"7"}},
+						&Call{"*6", Registers{"offset", "5"}, Registers{"7"}, &types.Type{
+							Kind: 2,
+						}},
 						&Assign{"8", &ast.Literal{&types.Type{
 							Kind: 6,
 						}, "1", nil, nil, "lib/strings/index.ok:79:45"}, ""},
@@ -1384,7 +1370,9 @@ func init() {
 								},
 							},
 						}, "Reverse", nil, nil, ""}, ""},
-						&Call{"*11", Registers{"s"}, Registers{"12"}},
+						&Call{"*11", Registers{"s"}, Registers{"12"}, &types.Type{
+							Kind: 2,
+						}},
 						&Assign{"13", &ast.Literal{&types.Type{
 							Kind: 10,
 							Arguments: []*types.Type{
@@ -1398,7 +1386,9 @@ func init() {
 								},
 							},
 						}, "Reverse", nil, nil, ""}, ""},
-						&Call{"*13", Registers{"substr"}, Registers{"14"}},
+						&Call{"*13", Registers{"substr"}, Registers{"14"}, &types.Type{
+							Kind: 2,
+						}},
 						&Assign{"15", &ast.Literal{&types.Type{
 							Kind: 10,
 							Arguments: []*types.Type{
@@ -1418,7 +1408,9 @@ func init() {
 								},
 							},
 						}, "IndexAfter", nil, nil, ""}, ""},
-						&Call{"*15", Registers{"12", "14", "offset"}, Registers{"16"}},
+						&Call{"*15", Registers{"12", "14", "offset"}, Registers{"16"}, &types.Type{
+							Kind: 2,
+						}},
 						&Assign{"index", nil, "16"},
 						&Assign{"17", &ast.Literal{&types.Type{
 							Kind: 6,
@@ -1450,7 +1442,6 @@ func init() {
 							Kind: 7,
 						},
 					},
-					Interfaces: nil,
 				},
 				"PadLeft": &CompiledFunc{
 					Arguments: []string{"s", "pad", "toLen"},
@@ -1482,7 +1473,9 @@ func init() {
 								},
 							},
 						}, "createPad", nil, nil, ""}, ""},
-						&Call{"*11", Registers{"pad", "10"}, Registers{"12"}},
+						&Call{"*11", Registers{"pad", "10"}, Registers{"12"}, &types.Type{
+							Kind: 2,
+						}},
 						&Concat{"12", "s", "13"},
 						&Return{Registers{"13"}},
 					},
@@ -1498,7 +1491,6 @@ func init() {
 							Kind: 6,
 						},
 					},
-					Interfaces: nil,
 				},
 				"PadRight": &CompiledFunc{
 					Arguments: []string{"s", "pad", "toLen"},
@@ -1530,7 +1522,9 @@ func init() {
 								},
 							},
 						}, "createPad", nil, nil, ""}, ""},
-						&Call{"*11", Registers{"pad", "10"}, Registers{"12"}},
+						&Call{"*11", Registers{"pad", "10"}, Registers{"12"}, &types.Type{
+							Kind: 2,
+						}},
 						&Concat{"s", "12", "13"},
 						&Return{Registers{"13"}},
 					},
@@ -1546,7 +1540,6 @@ func init() {
 							Kind: 6,
 						},
 					},
-					Interfaces: nil,
 				},
 				"Repeat": &CompiledFunc{
 					Arguments: []string{"str", "times"},
@@ -1584,7 +1577,6 @@ func init() {
 							Kind: 6,
 						},
 					},
-					Interfaces: nil,
 				},
 				"ReplaceAll": &CompiledFunc{
 					Arguments: []string{"s", "find", "replace"},
@@ -1608,7 +1600,9 @@ func init() {
 								},
 							},
 						}, "Split", nil, nil, ""}, ""},
-						&Call{"*4", Registers{"s", "find"}, Registers{"5"}},
+						&Call{"*4", Registers{"s", "find"}, Registers{"5"}, &types.Type{
+							Kind: 2,
+						}},
 						&Assign{"6", &ast.Literal{&types.Type{
 							Kind: 10,
 							Arguments: []*types.Type{
@@ -1628,7 +1622,9 @@ func init() {
 								},
 							},
 						}, "Join", nil, nil, ""}, ""},
-						&Call{"*6", Registers{"5", "replace"}, Registers{"7"}},
+						&Call{"*6", Registers{"5", "replace"}, Registers{"7"}, &types.Type{
+							Kind: 2,
+						}},
 						&Return{Registers{"7"}},
 					},
 					Registers: 7,
@@ -1643,7 +1639,6 @@ func init() {
 							Kind: 7,
 						},
 					},
-					Interfaces: nil,
 				},
 				"Reverse": &CompiledFunc{
 					Arguments: []string{"s"},
@@ -1685,7 +1680,6 @@ func init() {
 							Kind: 7,
 						},
 					},
-					Interfaces: nil,
 				},
 				"Split": &CompiledFunc{
 					Arguments: []string{"s", "delimiter"},
@@ -1768,7 +1762,9 @@ func init() {
 								},
 							},
 						}, "IndexAfter", nil, nil, ""}, ""},
-						&Call{"*22", Registers{"s", "delimiter", "21"}, Registers{"23"}},
+						&Call{"*22", Registers{"s", "delimiter", "21"}, Registers{"23"}, &types.Type{
+							Kind: 2,
+						}},
 						&Subtract{"23", "i", "24"},
 						&Assign{"25", &ast.Literal{&types.Type{
 							Kind: 6,
@@ -1845,7 +1841,6 @@ func init() {
 							Kind: 7,
 						},
 					},
-					Interfaces: nil,
 				},
 				"Substr": &CompiledFunc{
 					Arguments: []string{"s", "fromIndex", "toIndex"},
@@ -1885,7 +1880,6 @@ func init() {
 							Kind: 6,
 						},
 					},
-					Interfaces: nil,
 				},
 				"ToLower": &CompiledFunc{
 					Arguments: []string{"s"},
@@ -1941,7 +1935,6 @@ func init() {
 							Kind: 7,
 						},
 					},
-					Interfaces: nil,
 				},
 				"ToUpper": &CompiledFunc{
 					Arguments: []string{"s"},
@@ -1997,7 +1990,6 @@ func init() {
 							Kind: 7,
 						},
 					},
-					Interfaces: nil,
 				},
 				"Trim": &CompiledFunc{
 					Arguments: []string{"s", "cutset"},
@@ -2018,7 +2010,9 @@ func init() {
 								},
 							},
 						}, "TrimLeft", nil, nil, ""}, ""},
-						&Call{"*3", Registers{"s", "cutset"}, Registers{"4"}},
+						&Call{"*3", Registers{"s", "cutset"}, Registers{"4"}, &types.Type{
+							Kind: 2,
+						}},
 						&Assign{"5", &ast.Literal{&types.Type{
 							Kind: 10,
 							Arguments: []*types.Type{
@@ -2035,7 +2029,9 @@ func init() {
 								},
 							},
 						}, "TrimRight", nil, nil, ""}, ""},
-						&Call{"*5", Registers{"4", "cutset"}, Registers{"6"}},
+						&Call{"*5", Registers{"4", "cutset"}, Registers{"6"}, &types.Type{
+							Kind: 2,
+						}},
 						&Return{Registers{"6"}},
 					},
 					Registers: 6,
@@ -2047,7 +2043,6 @@ func init() {
 							Kind: 7,
 						},
 					},
-					Interfaces: nil,
 				},
 				"TrimLeft": &CompiledFunc{
 					Arguments: []string{"s", "cutset"},
@@ -2077,7 +2072,9 @@ func init() {
 								},
 							},
 						}, "Index", nil, nil, ""}, ""},
-						&Call{"*8", Registers{"cutset", "7"}, Registers{"9"}},
+						&Call{"*8", Registers{"cutset", "7"}, Registers{"9"}, &types.Type{
+							Kind: 2,
+						}},
 						&Assign{"10", &ast.Literal{&types.Type{
 							Kind: 6,
 						}, "-1", nil, nil, "lib/strings/trim.ok:5:47"}, ""},
@@ -2099,7 +2096,9 @@ func init() {
 								},
 							},
 						}, "substrFrom", nil, nil, ""}, ""},
-						&Call{"*12", Registers{"s", "offset"}, Registers{"13"}},
+						&Call{"*12", Registers{"s", "offset"}, Registers{"13"}, &types.Type{
+							Kind: 2,
+						}},
 						&Return{Registers{"13"}},
 						&Assign{"14", &ast.Literal{&types.Type{
 							Kind: 6,
@@ -2120,7 +2119,6 @@ func init() {
 							Kind: 7,
 						},
 					},
-					Interfaces: nil,
 				},
 				"TrimPrefix": &CompiledFunc{
 					Arguments: []string{"s", "prefix"},
@@ -2141,7 +2139,9 @@ func init() {
 								},
 							},
 						}, "HasPrefix", nil, nil, ""}, ""},
-						&Call{"*3", Registers{"s", "prefix"}, Registers{"4"}},
+						&Call{"*3", Registers{"s", "prefix"}, Registers{"4"}, &types.Type{
+							Kind: 2,
+						}},
 						&JumpUnless{"4", 6},
 						&Len{"prefix", "5"},
 						&Assign{"6", &ast.Literal{&types.Type{
@@ -2160,7 +2160,9 @@ func init() {
 								},
 							},
 						}, "substrFrom", nil, nil, ""}, ""},
-						&Call{"*6", Registers{"s", "5"}, Registers{"7"}},
+						&Call{"*6", Registers{"s", "5"}, Registers{"7"}, &types.Type{
+							Kind: 2,
+						}},
 						&Return{Registers{"7"}},
 						&Return{Registers{"s"}},
 					},
@@ -2173,7 +2175,6 @@ func init() {
 							Kind: 7,
 						},
 					},
-					Interfaces: nil,
 				},
 				"TrimRight": &CompiledFunc{
 					Arguments: []string{"s", "cutset"},
@@ -2191,7 +2192,9 @@ func init() {
 								},
 							},
 						}, "Reverse", nil, nil, ""}, ""},
-						&Call{"*3", Registers{"s"}, Registers{"4"}},
+						&Call{"*3", Registers{"s"}, Registers{"4"}, &types.Type{
+							Kind: 2,
+						}},
 						&Assign{"5", &ast.Literal{&types.Type{
 							Kind: 10,
 							Arguments: []*types.Type{
@@ -2208,7 +2211,9 @@ func init() {
 								},
 							},
 						}, "TrimLeft", nil, nil, ""}, ""},
-						&Call{"*5", Registers{"4", "cutset"}, Registers{"6"}},
+						&Call{"*5", Registers{"4", "cutset"}, Registers{"6"}, &types.Type{
+							Kind: 2,
+						}},
 						&Assign{"7", &ast.Literal{&types.Type{
 							Kind: 10,
 							Arguments: []*types.Type{
@@ -2222,7 +2227,9 @@ func init() {
 								},
 							},
 						}, "Reverse", nil, nil, ""}, ""},
-						&Call{"*7", Registers{"6"}, Registers{"8"}},
+						&Call{"*7", Registers{"6"}, Registers{"8"}, &types.Type{
+							Kind: 2,
+						}},
 						&Return{Registers{"8"}},
 					},
 					Registers: 8,
@@ -2234,7 +2241,6 @@ func init() {
 							Kind: 7,
 						},
 					},
-					Interfaces: nil,
 				},
 				"TrimSuffix": &CompiledFunc{
 					Arguments: []string{"s", "suffix"},
@@ -2252,7 +2258,9 @@ func init() {
 								},
 							},
 						}, "Reverse", nil, nil, ""}, ""},
-						&Call{"*3", Registers{"s"}, Registers{"4"}},
+						&Call{"*3", Registers{"s"}, Registers{"4"}, &types.Type{
+							Kind: 2,
+						}},
 						&Assign{"5", &ast.Literal{&types.Type{
 							Kind: 10,
 							Arguments: []*types.Type{
@@ -2266,7 +2274,9 @@ func init() {
 								},
 							},
 						}, "Reverse", nil, nil, ""}, ""},
-						&Call{"*5", Registers{"suffix"}, Registers{"6"}},
+						&Call{"*5", Registers{"suffix"}, Registers{"6"}, &types.Type{
+							Kind: 2,
+						}},
 						&Assign{"7", &ast.Literal{&types.Type{
 							Kind: 10,
 							Arguments: []*types.Type{
@@ -2283,7 +2293,9 @@ func init() {
 								},
 							},
 						}, "TrimPrefix", nil, nil, ""}, ""},
-						&Call{"*7", Registers{"4", "6"}, Registers{"8"}},
+						&Call{"*7", Registers{"4", "6"}, Registers{"8"}, &types.Type{
+							Kind: 2,
+						}},
 						&Assign{"9", &ast.Literal{&types.Type{
 							Kind: 10,
 							Arguments: []*types.Type{
@@ -2297,7 +2309,9 @@ func init() {
 								},
 							},
 						}, "Reverse", nil, nil, ""}, ""},
-						&Call{"*9", Registers{"8"}, Registers{"10"}},
+						&Call{"*9", Registers{"8"}, Registers{"10"}, &types.Type{
+							Kind: 2,
+						}},
 						&Return{Registers{"10"}},
 					},
 					Registers: 10,
@@ -2309,7 +2323,6 @@ func init() {
 							Kind: 7,
 						},
 					},
-					Interfaces: nil,
 				},
 				"createPad": &CompiledFunc{
 					Arguments: []string{"pad", "toLen"},
@@ -2332,7 +2345,9 @@ func init() {
 								},
 							},
 						}, "Repeat", nil, nil, ""}, ""},
-						&Call{"*5", Registers{"pad", "4"}, Registers{"6"}},
+						&Call{"*5", Registers{"pad", "4"}, Registers{"6"}, &types.Type{
+							Kind: 2,
+						}},
 						&Assign{"7", &ast.Literal{&types.Type{
 							Kind: 6,
 						}, "0", nil, nil, "lib/strings/pad.ok:28:50"}, ""},
@@ -2355,7 +2370,9 @@ func init() {
 								},
 							},
 						}, "Substr", nil, nil, ""}, ""},
-						&Call{"*8", Registers{"6", "7", "toLen"}, Registers{"9"}},
+						&Call{"*8", Registers{"6", "7", "toLen"}, Registers{"9"}, &types.Type{
+							Kind: 2,
+						}},
 						&Return{Registers{"9"}},
 					},
 					Registers: 9,
@@ -2367,7 +2384,6 @@ func init() {
 							Kind: 6,
 						},
 					},
-					Interfaces: nil,
 				},
 				"max": &CompiledFunc{
 					Arguments: []string{"a", "b"},
@@ -2386,7 +2402,6 @@ func init() {
 							Kind: 6,
 						},
 					},
-					Interfaces: nil,
 				},
 				"min": &CompiledFunc{
 					Arguments: []string{"a", "b"},
@@ -2405,7 +2420,6 @@ func init() {
 							Kind: 6,
 						},
 					},
-					Interfaces: nil,
 				},
 				"substrFrom": &CompiledFunc{
 					Arguments: []string{"s", "index"},
@@ -2439,7 +2453,6 @@ func init() {
 							Kind: 7,
 						},
 					},
-					Interfaces: nil,
 				},
 			},
 			FuncDefs: map[string]*ast.Func{
@@ -2901,8 +2914,7 @@ func init() {
 					Pos: "lib/strings/trim.ok:52:1",
 				},
 			},
-			Interfaces: nil,
-			Constants:  nil,
+			Constants: nil,
 		},
 	}
 }

--- a/vm/okc.go
+++ b/vm/okc.go
@@ -13,24 +13,10 @@ type File struct {
 	// Imports lists all the packages that this package relies on.
 	Imports map[string]map[string]*types.Type
 
-	Funcs      map[string]*CompiledFunc
-	FuncDefs   map[string]*ast.Func
-	Tests      []*CompiledTest
-	Interfaces map[string]map[string]*types.Type
-	Constants  map[string]*ast.Literal
-}
-
-func (f *File) ResolveType(t *types.Type) *types.Type {
-	// TODO(elliot): Remove me in the future.
-	if t.Name == "error.Error" {
-		return types.ErrorInterface
-	}
-
-	if t.Kind == types.KindUnresolvedInterface {
-		return types.NewInterface(t.Name, f.Interfaces[t.Name])
-	}
-
-	return t
+	Funcs     map[string]*CompiledFunc
+	FuncDefs  map[string]*ast.Func
+	Tests     []*CompiledTest
+	Constants map[string]*ast.Literal
 }
 
 // Store will create or replace the okc file for the provided package name.

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -48,35 +48,14 @@ type VM struct {
 
 	// FinallyBlocks are stacked with stack.
 	FinallyBlocks [][]*FinallyBlock
-
-	// Interfaces describes all the interfaces types known by the VM.
-	Interfaces map[string]map[string]*types.Type
 }
 
 // NewVM will create a new VM ready to run the provided instructions.
-func NewVM(
-	fns map[string]*CompiledFunc,
-	tests []*CompiledTest,
-	interfaces map[string]map[string]*types.Type,
-	pkg string,
-) *VM {
-	// The VM probably starts empty, make sure we prepare the fns for loading
-	// later. See LoadGob().
-	//
-	// TODO(elliot): Remove these.
-	if fns == nil {
-		fns = make(map[string]*CompiledFunc)
-	}
-	if interfaces == nil {
-		interfaces = make(map[string]map[string]*types.Type)
-	}
-
+func NewVM(pkg string) *VM {
 	return &VM{
-		fns:        fns,
-		tests:      tests,
-		pkg:        pkg,
-		Stdout:     os.Stdout,
-		Interfaces: interfaces,
+		fns:    make(map[string]*CompiledFunc),
+		pkg:    pkg,
+		Stdout: os.Stdout,
 	}
 }
 
@@ -381,13 +360,6 @@ func (vm *VM) LoadFile(pkgVariable string, file *File) error {
 			k = pkgVariable + "." + k
 		}
 		vm.fns[k] = v
-	}
-
-	for k, v := range file.Interfaces {
-		if pkgVariable != "" {
-			k = pkgVariable + "." + k
-		}
-		vm.Interfaces[k] = v
 	}
 
 	vm.tests = file.Tests


### PR DESCRIPTION
For ease, interfaces would be resolved in separate structures indexed by
their name. This wasn't a permanent solution, now:

- The compiler can retrieve the real interfaces from the types at
compile time.

- The VM will carry the runtime interfaces types through the Call
instruction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/ok/83)
<!-- Reviewable:end -->
