### PR TITLE
Packages are now compiled as a single function

### DIFF
--- a/ast/asttest/assert.go
+++ b/ast/asttest/assert.go
@@ -1,6 +1,7 @@
 package asttest
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/elliotchance/ok/ast"
@@ -10,6 +11,17 @@ import (
 )
 
 func AssertEqual(t *testing.T, fns1, fns2 interface{}) bool {
+	// TODO(elliot): This just ignores some transient data that will be removed
+	//  in the future. Remove this code to see what breaks (and fix it).
+	if m, ok := fns2.(map[string]*ast.Func); ok {
+		delete(m, "")
+		for k := range m {
+			if _, err := strconv.Atoi(k); err == nil {
+				delete(m, k)
+			}
+		}
+	}
+
 	return assert.Empty(t, cmp.Diff(fns1, fns2, cmpOptions()))
 }
 
@@ -26,6 +38,7 @@ func cmpOptions() cmp.Options {
 		cmpopts.IgnoreFields(ast.Finally{}, "Pos"),
 		cmpopts.IgnoreFields(ast.For{}, "Pos"),
 		cmpopts.IgnoreFields(ast.Func{}, "Pos"),
+		cmpopts.IgnoreFields(ast.Func{}, "UniqueName"),
 		cmpopts.IgnoreFields(ast.Group{}, "Pos"),
 		cmpopts.IgnoreFields(ast.Identifier{}, "Pos"),
 		cmpopts.IgnoreFields(ast.If{}, "Pos"),

--- a/ast/func.go
+++ b/ast/func.go
@@ -22,6 +22,10 @@ type Func struct {
 	// Name is the name of the function being declared.
 	Name string
 
+	// All functions have a unique name assigned to them so they can be
+	// referenced by the VM.
+	UniqueName string
+
 	// Arguments may contain zero or more elements. They will always be in the
 	// order in which their are declared.
 	Arguments []*Argument

--- a/cmd/asm/main.go
+++ b/cmd/asm/main.go
@@ -35,7 +35,7 @@ func (*Command) Run(args []string) {
 	check(err)
 
 	packageName := util.PackageNameFromPath(okPath, args[0])
-	pkg, errs := compiler.Compile(okPath, packageName, false)
+	pkg, errs := compiler.Compile(okPath, packageName, false, 0)
 	util.CheckErrorsWithExit(errs)
 
 	// Create a map as a function may match more than one glob.
@@ -68,7 +68,7 @@ func (*Command) Run(args []string) {
 			panic("no such function: " + fnName)
 		}
 
-		fmt.Println(fn.String() + ":")
+		fmt.Println(fn.UniqueName+":", fn.String()+":")
 
 		for i, ins := range pkg.Funcs[fn.Name].Instructions {
 			ty := fmt.Sprintf("%T", ins)[4:]

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -41,7 +41,7 @@ func runArg(arg string) {
 	check(err)
 
 	packageName := util.PackageNameFromPath(okPath, arg)
-	file, errs := compiler.Compile(okPath, packageName, false)
+	file, errs := compiler.Compile(okPath, packageName, false, 0)
 	util.CheckErrorsWithExit(errs)
 
 	goFile := path.Join(arg, "main.go")

--- a/cmd/doc/main.go
+++ b/cmd/doc/main.go
@@ -2,8 +2,8 @@ package doc
 
 import (
 	"fmt"
-	"log"
 	"sort"
+	"strconv"
 
 	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/parser"
@@ -11,12 +11,6 @@ import (
 )
 
 type Command struct{}
-
-func check(err error) {
-	if err != nil {
-		log.Fatalln(err)
-	}
-}
 
 // Description is shown in "ok -help".
 func (*Command) Description() string {
@@ -32,7 +26,7 @@ func (*Command) Run(args []string) {
 	for _, arg := range args {
 		packageName := util.PackageNameFromPath("", arg)
 
-		p := parser.NewParser()
+		p := parser.NewParser(0)
 		p.ParseDirectory(arg, false)
 
 		docs := map[string]string{}
@@ -40,7 +34,12 @@ func (*Command) Run(args []string) {
 		var constantNames []string
 		constants := map[string]*ast.Literal{}
 
-		for _, fn := range p.Funcs() {
+		for fnName, fn := range p.Funcs() {
+			// TODO(elliot): Remove this check.
+			if _, err := strconv.Atoi(fnName); err == nil {
+				continue
+			}
+
 			funcs = append(funcs, fn)
 		}
 

--- a/cmd/lib-gen/main.go
+++ b/cmd/lib-gen/main.go
@@ -33,7 +33,7 @@ func main() {
 			continue
 		}
 
-		f, errs := compiler.Compile("lib", pkgName, false)
+		f, errs := compiler.Compile("lib", pkgName, false, 0)
 		util.CheckErrorsWithExit(errs)
 
 		pkgs[pkgName] = f

--- a/cmd/run/main.go
+++ b/cmd/run/main.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"log"
+	"time"
 
 	"github.com/elliotchance/ok/compiler"
 	"github.com/elliotchance/ok/util"
@@ -34,7 +35,7 @@ func (*Command) Run(args []string) {
 		packageName := util.PackageNameFromPath(okPath, arg)
 
 		m := vm.NewVM("no-package")
-		_, errs := compiler.Compile(okPath, packageName, false)
+		_, errs := compiler.Compile(okPath, packageName, false, time.Now().Nanosecond())
 		util.CheckErrorsWithExit(errs)
 
 		check(m.LoadPackage("", packageName))

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -48,7 +48,7 @@ func (c *Command) Run(args []string) {
 
 	for _, arg := range args {
 		packageName := util.PackageNameFromPath(okPath, arg)
-		_, errs := compiler.Compile(okPath, packageName, true)
+		_, errs := compiler.Compile(okPath, packageName, true, 0)
 		util.CheckErrorsWithExit(errs)
 
 		m := vm.NewVM("no-package")

--- a/compiler/expr.go
+++ b/compiler/expr.go
@@ -32,8 +32,9 @@ func compileExpr(
 			return nil, nil, err
 		}
 
-		file.FuncDefs[e.Name] = e
-		file.Funcs[e.Name] = cf
+		file.FuncDefs[e.UniqueName] = e
+		file.Funcs[e.UniqueName] = cf
+
 		fnType := e.Type()
 
 		returns := compiledFunc.NextRegister()
@@ -41,7 +42,7 @@ func compileExpr(
 			VariableName: returns,
 			Value: &ast.Literal{
 				Kind:  fnType,
-				Value: e.Name,
+				Value: e.UniqueName,
 			},
 		})
 
@@ -129,7 +130,7 @@ func compileExpr(
 				VariableName: literalRegister,
 				Value: &ast.Literal{
 					Kind:  fn.Type(),
-					Value: fn.Name,
+					Value: fn.UniqueName,
 				},
 			})
 

--- a/parser/array_test.go
+++ b/parser/array_test.go
@@ -110,7 +110,7 @@ func TestArray(t *testing.T) {
 	} {
 		t.Run(testName, func(t *testing.T) {
 			str := fmt.Sprintf("func main() { %s }", test.str)
-			p := parser.NewParser()
+			p := parser.NewParser(0)
 			p.ParseString(str, "a.ok")
 
 			assertEqualErrors(t, test.errs, p.Errors())

--- a/parser/assert_test.go
+++ b/parser/assert_test.go
@@ -37,7 +37,7 @@ func TestAssert(t *testing.T) {
 	} {
 		t.Run(testName, func(t *testing.T) {
 			str := fmt.Sprintf("func main() { %s }", test.str)
-			p := parser.NewParser()
+			p := parser.NewParser(0)
 			p.ParseString(str, "a.ok")
 
 			assertEqualErrors(t, test.errs, p.Errors())

--- a/parser/assign_test.go
+++ b/parser/assign_test.go
@@ -79,14 +79,15 @@ func TestAssign(t *testing.T) {
 					&ast.Identifier{Name: "fn"},
 				},
 				Rights: []ast.Node{
-					&ast.Func{Name: "1"},
+					// UniqueName would be set, but is ignored by cmpOptions().
+					&ast.Func{},
 				},
 			},
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
 			str := fmt.Sprintf("func main() { %s }", test.str)
-			p := parser.NewParser()
+			p := parser.NewParser(0)
 			p.ParseString(str, "a.ok")
 
 			assert.Nil(t, p.Errors())

--- a/parser/call_test.go
+++ b/parser/call_test.go
@@ -67,7 +67,7 @@ func TestCall(t *testing.T) {
 	} {
 		t.Run(testName, func(t *testing.T) {
 			str := fmt.Sprintf("func main() { %s }", test.str)
-			p := parser.NewParser()
+			p := parser.NewParser(0)
 			p.ParseString(str, "a.ok")
 
 			assert.Empty(t, p.Errors().String())

--- a/parser/error_scope_test.go
+++ b/parser/error_scope_test.go
@@ -118,7 +118,7 @@ func TestErrorScope(t *testing.T) {
 	} {
 		t.Run(testName, func(t *testing.T) {
 			str := fmt.Sprintf("func main() { %s }", test.str)
-			p := parser.NewParser()
+			p := parser.NewParser(0)
 			p.ParseString(str, "a.ok")
 
 			assertEqualErrors(t, test.errs, p.Errors())

--- a/parser/expr_test.go
+++ b/parser/expr_test.go
@@ -459,7 +459,7 @@ func TestExpr(t *testing.T) {
 	} {
 		t.Run(testName, func(t *testing.T) {
 			str := fmt.Sprintf("func main() { %s }", test.str)
-			p := parser.NewParser()
+			p := parser.NewParser(0)
 			p.ParseString(str, "a.ok")
 
 			assertEqualErrors(t, test.errs, p.Errors())

--- a/parser/for_test.go
+++ b/parser/for_test.go
@@ -207,7 +207,7 @@ func TestFor(t *testing.T) {
 	} {
 		t.Run(testName, func(t *testing.T) {
 			str := fmt.Sprintf("func main() { %s }", test.str)
-			p := parser.NewParser()
+			p := parser.NewParser(0)
 			p.ParseString(str, "a.ok")
 
 			assertEqualErrors(t, test.errs, p.Errors())

--- a/parser/func.go
+++ b/parser/func.go
@@ -16,7 +16,8 @@ func consumeFunc(parser *Parser, offset int) (_ *ast.Func, _ int, anon bool, fin
 	}
 
 	fn := &ast.Func{
-		Pos: parser.pos(originalOffset),
+		Pos:        parser.pos(originalOffset),
+		UniqueName: parser.nextFunctionName(),
 	}
 
 	// The name of the function is optional. For anonymous functions we will
@@ -28,7 +29,6 @@ func consumeFunc(parser *Parser, offset int) (_ *ast.Func, _ int, anon bool, fin
 	if err == nil {
 		fn.Name = parser.tokens[offset-1].Value
 	} else {
-		fn.Name = parser.nextFunctionName()
 		anon = true
 	}
 

--- a/parser/func_test.go
+++ b/parser/func_test.go
@@ -200,15 +200,9 @@ func TestFunc(t *testing.T) {
 				},
 			},
 		},
-		"function-without-name": {
-			str: "func () {}",
-			expected: map[string]*ast.Func{
-				"1": {Name: "1"},
-			},
-		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			p := parser.NewParser()
+			p := parser.NewParser(0)
 			p.ParseString(test.str, "a.ok")
 
 			assert.Nil(t, p.Errors())

--- a/parser/if_test.go
+++ b/parser/if_test.go
@@ -100,7 +100,7 @@ func TestIf(t *testing.T) {
 	} {
 		t.Run(testName, func(t *testing.T) {
 			str := fmt.Sprintf("func main() { %s }", test.str)
-			p := parser.NewParser()
+			p := parser.NewParser(0)
 			p.ParseString(str, "a.ok")
 
 			assertEqualErrors(t, test.errs, p.Errors())

--- a/parser/import_test.go
+++ b/parser/import_test.go
@@ -20,7 +20,7 @@ func TestImport(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			p := parser.NewParser()
+			p := parser.NewParser(0)
 			p.ParseString(test.str, "a.ok")
 
 			assert.Nil(t, p.Errors())

--- a/parser/interpolate_test.go
+++ b/parser/interpolate_test.go
@@ -70,7 +70,7 @@ func TestInterpolate(t *testing.T) {
 	} {
 		t.Run(testName, func(t *testing.T) {
 			str := fmt.Sprintf("func main() { %s }", test.str)
-			p := parser.NewParser()
+			p := parser.NewParser(0)
 			p.ParseString(str, "a.ok")
 
 			assertEqualErrors(t, test.errs, p.Errors())

--- a/parser/map_test.go
+++ b/parser/map_test.go
@@ -130,7 +130,7 @@ func TestMap(t *testing.T) {
 	} {
 		t.Run(testName, func(t *testing.T) {
 			str := fmt.Sprintf("func main() { %s }", test.str)
-			p := parser.NewParser()
+			p := parser.NewParser(0)
 			p.ParseString(str, "a.ok")
 
 			assertEqualErrors(t, test.errs, p.Errors())

--- a/parser/object_test.go
+++ b/parser/object_test.go
@@ -39,7 +39,7 @@ func TestObject(t *testing.T) {
 	} {
 		t.Run(testName, func(t *testing.T) {
 			str := fmt.Sprintf("func main() { %s }", test.str)
-			p := parser.NewParser()
+			p := parser.NewParser(0)
 			p.ParseString(str, "a.ok")
 
 			assertEqualErrors(t, test.errs, p.Errors())

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -62,7 +62,13 @@ func (parser *Parser) ParseString(s string, fileName string) {
 
 				goto done
 			}
+
+			// TODO(elliot): Remove this. We need to index by real name for
+			//  resolving types. But this also means that types can't exist
+			//  beyond the root level.
 			parser.funcs[fn.Name] = fn
+
+			parser.funcs[fn.UniqueName] = fn
 
 		case lexer.TokenTest:
 			var t *ast.Test

--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -14,11 +14,11 @@ import (
 
 func TestParser_Funcs(t *testing.T) {
 	t.Run("main function", func(t *testing.T) {
-		p := parser.NewParser()
+		p := parser.NewParser(0)
 		p.ParseString(`func main() { }`, "a.ok")
 		require.Nil(t, p.Errors())
 
-		assert.Equal(t, map[string]*ast.Func{
+		asttest.AssertEqual(t, map[string]*ast.Func{
 			"main": {
 				Name: "main",
 				Pos:  "a.ok:1:1",
@@ -27,12 +27,12 @@ func TestParser_Funcs(t *testing.T) {
 	})
 
 	t.Run("calling ParseString multiple times appends functions", func(t *testing.T) {
-		p := parser.NewParser()
+		p := parser.NewParser(0)
 		p.ParseString(`func main() { }`, "a.ok")
 		p.ParseString(`func foo() { }`, "a.ok")
 		require.Nil(t, p.Errors())
 
-		assert.Equal(t, map[string]*ast.Func{
+		asttest.AssertEqual(t, map[string]*ast.Func{
 			"main": {
 				Name: "main",
 				Pos:  "a.ok:1:1",
@@ -45,7 +45,7 @@ func TestParser_Funcs(t *testing.T) {
 	})
 
 	t.Run("normal function type", func(t *testing.T) {
-		p := parser.NewParser()
+		p := parser.NewParser(0)
 		p.ParseString(`func main(a, b number) string { }`, "a.ok")
 		require.Nil(t, p.Errors())
 
@@ -57,7 +57,7 @@ func TestParser_Funcs(t *testing.T) {
 	})
 
 	t.Run("constructor function", func(t *testing.T) {
-		p := parser.NewParser()
+		p := parser.NewParser(0)
 		p.ParseString(`
 func Person(Foo, bar, Baz number) Person {
 	func Qux() string { }
@@ -91,7 +91,7 @@ func Person(Foo, bar, Baz number) Person {
 	})
 
 	t.Run("resolve interfaces in return types", func(t *testing.T) {
-		p := parser.NewParser()
+		p := parser.NewParser(0)
 		p.ParseString(`
 func Person(Foo, Bar number) Person { }
 func getPerson() (number, Person) { }
@@ -115,7 +115,7 @@ func getPerson() (number, Person) { }
 	})
 
 	t.Run("resolve interfaces in arguments", func(t *testing.T) {
-		p := parser.NewParser()
+		p := parser.NewParser(0)
 		p.ParseString(`
 func Person(Foo, Bar number) Person { }
 func greetPerson(p Person, n number) { }
@@ -346,7 +346,7 @@ func TestParser_ParseString(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			p := parser.NewParser()
+			p := parser.NewParser(0)
 			p.ParseString(test.str, "a.ok")
 
 			assertEqualErrors(t, test.errs, p.Errors())

--- a/parser/raise_test.go
+++ b/parser/raise_test.go
@@ -49,7 +49,7 @@ func TestRaise(t *testing.T) {
 	} {
 		t.Run(testName, func(t *testing.T) {
 			str := fmt.Sprintf("func main() { %s }", test.str)
-			p := parser.NewParser()
+			p := parser.NewParser(0)
 			p.ParseString(str, "a.ok")
 
 			assertEqualErrors(t, test.errs, p.Errors())

--- a/parser/return_test.go
+++ b/parser/return_test.go
@@ -39,7 +39,7 @@ func TestReturn(t *testing.T) {
 	} {
 		t.Run(testName, func(t *testing.T) {
 			str := fmt.Sprintf("func main() { %s }", test.str)
-			p := parser.NewParser()
+			p := parser.NewParser(0)
 			p.ParseString(str, "a.ok")
 
 			assertEqualErrors(t, test.errs, p.Errors())

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -26,8 +26,7 @@ func consumeStatement(parser *Parser, offset int) (_ ast.Node, _ int, hoist bool
 	}
 
 	var fn *ast.Func
-	var fnAnon bool
-	fn, offset, fnAnon, err = consumeFunc(parser, offset)
+	fn, offset, _, err = consumeFunc(parser, offset)
 	if err == nil {
 		assign := &ast.Assign{
 			Lefts: []ast.Node{
@@ -36,12 +35,6 @@ func consumeStatement(parser *Parser, offset int) (_ ast.Node, _ int, hoist bool
 			Rights: []ast.Node{
 				fn,
 			},
-		}
-
-		// If the function literal has a name it will confuse the compiler into
-		// thinking it's a package-level entity.
-		if !fnAnon {
-			fn.Name = parser.nextFunctionName()
 		}
 
 		// It's not enough to simply translate a nested function into a variable

--- a/parser/switch_test.go
+++ b/parser/switch_test.go
@@ -160,7 +160,7 @@ func TestSwitch(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			p := parser.NewParser()
+			p := parser.NewParser(0)
 			p.ParseString(test.str, "a.ok")
 
 			assertEqualErrors(t, test.errs, p.Errors())

--- a/parser/test_test.go
+++ b/parser/test_test.go
@@ -24,7 +24,7 @@ func TestTest(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			p := parser.NewParser()
+			p := parser.NewParser(0)
 			p.ParseString(test.str, "a.ok")
 
 			assertEqualErrors(t, test.errs, p.Errors())

--- a/parser/type_test.go
+++ b/parser/type_test.go
@@ -75,7 +75,7 @@ func TestType(t *testing.T) {
 	} {
 		t.Run(testName, func(t *testing.T) {
 			str := fmt.Sprintf("func main() { %s }", test.str)
-			p := parser.NewParser()
+			p := parser.NewParser(0)
 			p.ParseString(str, "a.ok")
 
 			require.Empty(t, p.Errors().String(), str)

--- a/vm/lib.go
+++ b/vm/lib.go
@@ -8,6 +8,18 @@ func init() {
 		"error": &File{
 			Imports: nil,
 			Funcs: map[string]*CompiledFunc{
+				"1": &CompiledFunc{
+					Arguments: []string{"Error"},
+					Instructions: []Instruction{
+						&Return{Registers{"0"}},
+					},
+					Registers: 1,
+					Variables: map[string]*types.Type{
+						"Error": &types.Type{
+							Kind: 7,
+						},
+					},
+				},
 				"Error": &CompiledFunc{
 					Arguments: []string{"Error"},
 					Instructions: []Instruction{
@@ -22,8 +34,30 @@ func init() {
 				},
 			},
 			FuncDefs: map[string]*ast.Func{
+				"1": &ast.Func{
+					Name:       "Error",
+					UniqueName: "1",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"Error", &types.Type{
+							Kind: 7,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 1,
+							Name: "Error",
+							Properties: map[string]*types.Type{
+								"Error": &types.Type{
+									Kind: 7,
+								},
+							},
+						},
+					},
+					Pos: "lib/error/error.ok:2:1",
+				},
 				"Error": &ast.Func{
-					Name: "Error",
+					Name:       "Error",
+					UniqueName: "1",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"Error", &types.Type{
 							Kind: 7,
@@ -44,10 +78,379 @@ func init() {
 				},
 			},
 			Constants: nil,
+			PackageFunc: &CompiledFunc{
+				Instructions: []Instruction{
+					&Assign{"1", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 1,
+								Name: "Error",
+								Properties: map[string]*types.Type{
+									"Error": &types.Type{
+										Kind: 7,
+									},
+								},
+							},
+						},
+					}, "1", nil, nil, ""}, ""},
+					&ParentScope{"1"},
+					&Assign{"1", nil, "1"},
+					&Assign{"2", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 1,
+								Name: "Error",
+								Properties: map[string]*types.Type{
+									"Error": &types.Type{
+										Kind: 7,
+									},
+								},
+							},
+						},
+					}, "1", nil, nil, ""}, ""},
+					&ParentScope{"2"},
+					&Assign{"Error", nil, "2"},
+					&Return{Registers{"0"}},
+				},
+				Registers: 2,
+				Variables: map[string]*types.Type{
+					"1": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 1,
+								Name: "Error",
+								Properties: map[string]*types.Type{
+									"Error": &types.Type{
+										Kind: 7,
+									},
+								},
+							},
+						},
+					},
+					"Error": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 1,
+								Name: "Error",
+								Properties: map[string]*types.Type{
+									"Error": &types.Type{
+										Kind: 7,
+									},
+								},
+							},
+						},
+					},
+				},
+				Type: &types.Type{
+					Kind: 10,
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 1,
+							Name: "..__error",
+							Properties: map[string]*types.Type{
+								"Error": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 1,
+											Name: "Error",
+											Properties: map[string]*types.Type{
+												"Error": &types.Type{
+													Kind: 7,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		"math": &File{
 			Imports: nil,
 			Funcs: map[string]*CompiledFunc{
+				"1": &CompiledFunc{
+					Arguments: []string{"x"},
+					Instructions: []Instruction{
+						&Assign{"2", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "0", nil, nil, "lib/math/abs.ok:3:12"}, ""},
+						&LessThanNumber{"x", "2", "3"},
+						&JumpUnless{"3", 5},
+						&Assign{"4", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "0", nil, nil, ""}, ""},
+						&Subtract{"4", "x", "5"},
+						&Return{Registers{"5"}},
+						&Return{Registers{"x"}},
+					},
+					Registers: 5,
+					Variables: map[string]*types.Type{
+						"x": &types.Type{
+							Kind: 6,
+						},
+					},
+				},
+				"10": &CompiledFunc{
+					Arguments: []string{"x", "prec"},
+					Instructions: []Instruction{
+						&Assign{"3", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "10", nil, nil, "lib/math/rounding.ok:32:15"}, ""},
+						&Power{"3", "prec", "4"},
+						&Assign{"p", nil, "4"},
+						&Multiply{"x", "p", "5"},
+						&Assign{"y", nil, "5"},
+						&Assign{"6", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, "lib/math/rounding.ok:35:16"}, ""},
+						&Remainder{"y", "6", "7"},
+						&Assign{"diff", nil, "7"},
+						&Assign{"8", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "0.5", nil, nil, "lib/math/rounding.ok:36:16"}, ""},
+						&GreaterThanEqualNumber{"diff", "8", "9"},
+						&JumpUnless{"9", 15},
+						&Assign{"10", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, "lib/math/rounding.ok:37:22"}, ""},
+						&Subtract{"10", "diff", "11"},
+						&Add{"y", "11", "12"},
+						&Divide{"12", "p", "13"},
+						&Return{Registers{"13"}},
+						&Subtract{"y", "diff", "14"},
+						&Divide{"14", "p", "15"},
+						&Return{Registers{"15"}},
+					},
+					Registers: 15,
+					Variables: map[string]*types.Type{
+						"diff": &types.Type{
+							Kind: 6,
+						},
+						"p": &types.Type{
+							Kind: 6,
+						},
+						"prec": &types.Type{
+							Kind: 6,
+						},
+						"x": &types.Type{
+							Kind: 6,
+						},
+						"y": &types.Type{
+							Kind: 6,
+						},
+					},
+				},
+				"2": &CompiledFunc{
+					Arguments: []string{"x"},
+					Instructions: []Instruction{
+						&Log{"x", "2"},
+						&Return{Registers{"2"}},
+					},
+					Registers: 2,
+					Variables: map[string]*types.Type{
+						"x": &types.Type{
+							Kind: 6,
+						},
+					},
+				},
+				"3": &CompiledFunc{
+					Arguments: []string{"x"},
+					Instructions: []Instruction{
+						&Log{"x", "2"},
+						&Assign{"3", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "10", nil, nil, "lib/math/log.ok:8:29"}, ""},
+						&Log{"3", "4"},
+						&Divide{"2", "4", "5"},
+						&Return{Registers{"5"}},
+					},
+					Registers: 5,
+					Variables: map[string]*types.Type{
+						"x": &types.Type{
+							Kind: 6,
+						},
+					},
+				},
+				"4": &CompiledFunc{
+					Arguments: []string{"x"},
+					Instructions: []Instruction{
+						&Assign{"2", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "2.71828182845904523536028747135266249775724709369995", nil, nil, "lib/math/powers.ok:4:9"}, ""},
+						&Assign{"e", nil, "2"},
+						&Power{"e", "x", "3"},
+						&Return{Registers{"3"}},
+					},
+					Registers: 3,
+					Variables: map[string]*types.Type{
+						"e": &types.Type{
+							Kind: 6,
+						},
+						"x": &types.Type{
+							Kind: 6,
+						},
+					},
+				},
+				"5": &CompiledFunc{
+					Arguments: []string{"base", "power"},
+					Instructions: []Instruction{
+						&Power{"base", "power", "3"},
+						&Return{Registers{"3"}},
+					},
+					Registers: 3,
+					Variables: map[string]*types.Type{
+						"base": &types.Type{
+							Kind: 6,
+						},
+						"power": &types.Type{
+							Kind: 6,
+						},
+					},
+				},
+				"6": &CompiledFunc{
+					Arguments: []string{"x"},
+					Instructions: []Instruction{
+						&Assign{"2", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "0.5", nil, nil, "lib/math/powers.ok:16:21"}, ""},
+						&Power{"x", "2", "3"},
+						&Return{Registers{"3"}},
+					},
+					Registers: 3,
+					Variables: map[string]*types.Type{
+						"x": &types.Type{
+							Kind: 6,
+						},
+					},
+				},
+				"7": &CompiledFunc{
+					Arguments: []string{"x"},
+					Instructions: []Instruction{
+						&Assign{"2", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, "lib/math/powers.ok:21:21"}, ""},
+						&Assign{"3", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "3", nil, nil, "lib/math/powers.ok:21:23"}, ""},
+						&Divide{"2", "3", "4"},
+						&Power{"x", "4", "5"},
+						&Return{Registers{"5"}},
+					},
+					Registers: 5,
+					Variables: map[string]*types.Type{
+						"x": &types.Type{
+							Kind: 6,
+						},
+					},
+				},
+				"8": &CompiledFunc{
+					Arguments: []string{"x"},
+					Instructions: []Instruction{
+						&Assign{"2", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, "lib/math/rounding.ok:3:16"}, ""},
+						&Remainder{"x", "2", "3"},
+						&Assign{"frac", nil, "3"},
+						&Assign{"4", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "0", nil, nil, "lib/math/rounding.ok:4:16"}, ""},
+						&EqualNumber{"frac", "4", "5"},
+						&JumpUnless{"5", 6},
+						&Return{Registers{"x"}},
+						&Assign{"6", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "0", nil, nil, "lib/math/rounding.ok:8:12"}, ""},
+						&LessThanNumber{"x", "6", "7"},
+						&JumpUnless{"7", 11},
+						&Subtract{"x", "frac", "8"},
+						&Return{Registers{"8"}},
+						&Assign{"9", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, "lib/math/rounding.ok:12:17"}, ""},
+						&Subtract{"9", "frac", "10"},
+						&Add{"x", "10", "11"},
+						&Return{Registers{"11"}},
+					},
+					Registers: 11,
+					Variables: map[string]*types.Type{
+						"frac": &types.Type{
+							Kind: 6,
+						},
+						"x": &types.Type{
+							Kind: 6,
+						},
+					},
+				},
+				"9": &CompiledFunc{
+					Arguments: []string{"x"},
+					Instructions: []Instruction{
+						&Assign{"2", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, "lib/math/rounding.ok:17:16"}, ""},
+						&Remainder{"x", "2", "3"},
+						&Assign{"frac", nil, "3"},
+						&Assign{"4", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "0", nil, nil, "lib/math/rounding.ok:18:16"}, ""},
+						&EqualNumber{"frac", "4", "5"},
+						&JumpUnless{"5", 6},
+						&Return{Registers{"x"}},
+						&Assign{"6", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "0", nil, nil, "lib/math/rounding.ok:22:12"}, ""},
+						&LessThanNumber{"x", "6", "7"},
+						&JumpUnless{"7", 13},
+						&Assign{"8", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, "lib/math/rounding.ok:23:27"}, ""},
+						&Add{"frac", "8", "9"},
+						&Subtract{"x", "9", "10"},
+						&Return{Registers{"10"}},
+						&Subtract{"x", "frac", "11"},
+						&Return{Registers{"11"}},
+					},
+					Registers: 11,
+					Variables: map[string]*types.Type{
+						"frac": &types.Type{
+							Kind: 6,
+						},
+						"x": &types.Type{
+							Kind: 6,
+						},
+					},
+				},
 				"Abs": &CompiledFunc{
 					Arguments: []string{"x"},
 					Instructions: []Instruction{
@@ -301,8 +704,165 @@ func init() {
 				},
 			},
 			FuncDefs: map[string]*ast.Func{
+				"1": &ast.Func{
+					Name:       "Abs",
+					UniqueName: "1",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"x", &types.Type{
+							Kind: 6,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 6,
+						},
+					},
+					Pos: "lib/math/abs.ok:2:1",
+				},
+				"10": &ast.Func{
+					Name:       "Round",
+					UniqueName: "10",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"x", &types.Type{
+							Kind: 6,
+						}},
+						&ast.Argument{"prec", &types.Type{
+							Kind: 6,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 6,
+						},
+					},
+					Pos: "lib/math/rounding.ok:31:1",
+				},
+				"2": &ast.Func{
+					Name:       "LogE",
+					UniqueName: "2",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"x", &types.Type{
+							Kind: 6,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 6,
+						},
+					},
+					Pos: "lib/math/log.ok:2:1",
+				},
+				"3": &ast.Func{
+					Name:       "Log10",
+					UniqueName: "3",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"x", &types.Type{
+							Kind: 6,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 6,
+						},
+					},
+					Pos: "lib/math/log.ok:7:1",
+				},
+				"4": &ast.Func{
+					Name:       "Exp",
+					UniqueName: "4",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"x", &types.Type{
+							Kind: 6,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 6,
+						},
+					},
+					Pos: "lib/math/powers.ok:2:1",
+				},
+				"5": &ast.Func{
+					Name:       "Pow",
+					UniqueName: "5",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"base", &types.Type{
+							Kind: 6,
+						}},
+						&ast.Argument{"power", &types.Type{
+							Kind: 6,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 6,
+						},
+					},
+					Pos: "lib/math/powers.ok:10:1",
+				},
+				"6": &ast.Func{
+					Name:       "Sqrt",
+					UniqueName: "6",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"x", &types.Type{
+							Kind: 6,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 6,
+						},
+					},
+					Pos: "lib/math/powers.ok:15:1",
+				},
+				"7": &ast.Func{
+					Name:       "Cbrt",
+					UniqueName: "7",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"x", &types.Type{
+							Kind: 6,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 6,
+						},
+					},
+					Pos: "lib/math/powers.ok:20:1",
+				},
+				"8": &ast.Func{
+					Name:       "Ceil",
+					UniqueName: "8",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"x", &types.Type{
+							Kind: 6,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 6,
+						},
+					},
+					Pos: "lib/math/rounding.ok:2:1",
+				},
+				"9": &ast.Func{
+					Name:       "Floor",
+					UniqueName: "9",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"x", &types.Type{
+							Kind: 6,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 6,
+						},
+					},
+					Pos: "lib/math/rounding.ok:16:1",
+				},
 				"Abs": &ast.Func{
-					Name: "Abs",
+					Name:       "Abs",
+					UniqueName: "1",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"x", &types.Type{
 							Kind: 6,
@@ -316,7 +876,8 @@ func init() {
 					Pos: "lib/math/abs.ok:2:1",
 				},
 				"Cbrt": &ast.Func{
-					Name: "Cbrt",
+					Name:       "Cbrt",
+					UniqueName: "7",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"x", &types.Type{
 							Kind: 6,
@@ -330,7 +891,8 @@ func init() {
 					Pos: "lib/math/powers.ok:20:1",
 				},
 				"Ceil": &ast.Func{
-					Name: "Ceil",
+					Name:       "Ceil",
+					UniqueName: "8",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"x", &types.Type{
 							Kind: 6,
@@ -344,7 +906,8 @@ func init() {
 					Pos: "lib/math/rounding.ok:2:1",
 				},
 				"Exp": &ast.Func{
-					Name: "Exp",
+					Name:       "Exp",
+					UniqueName: "4",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"x", &types.Type{
 							Kind: 6,
@@ -358,7 +921,8 @@ func init() {
 					Pos: "lib/math/powers.ok:2:1",
 				},
 				"Floor": &ast.Func{
-					Name: "Floor",
+					Name:       "Floor",
+					UniqueName: "9",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"x", &types.Type{
 							Kind: 6,
@@ -372,7 +936,8 @@ func init() {
 					Pos: "lib/math/rounding.ok:16:1",
 				},
 				"Log10": &ast.Func{
-					Name: "Log10",
+					Name:       "Log10",
+					UniqueName: "3",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"x", &types.Type{
 							Kind: 6,
@@ -386,7 +951,8 @@ func init() {
 					Pos: "lib/math/log.ok:7:1",
 				},
 				"LogE": &ast.Func{
-					Name: "LogE",
+					Name:       "LogE",
+					UniqueName: "2",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"x", &types.Type{
 							Kind: 6,
@@ -400,7 +966,8 @@ func init() {
 					Pos: "lib/math/log.ok:2:1",
 				},
 				"Pow": &ast.Func{
-					Name: "Pow",
+					Name:       "Pow",
+					UniqueName: "5",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"base", &types.Type{
 							Kind: 6,
@@ -417,7 +984,8 @@ func init() {
 					Pos: "lib/math/powers.ok:10:1",
 				},
 				"Round": &ast.Func{
-					Name: "Round",
+					Name:       "Round",
+					UniqueName: "10",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"x", &types.Type{
 							Kind: 6,
@@ -434,7 +1002,8 @@ func init() {
 					Pos: "lib/math/rounding.ok:31:1",
 				},
 				"Sqrt": &ast.Func{
-					Name: "Sqrt",
+					Name:       "Sqrt",
+					UniqueName: "6",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"x", &types.Type{
 							Kind: 6,
@@ -477,10 +1046,1111 @@ func init() {
 					Kind: 6,
 				}, "1.77245385090551602729816748334114518279754945612238712821380779", nil, nil, "lib/math/constants.ok:7:11"},
 			},
+			PackageFunc: &CompiledFunc{
+				Instructions: []Instruction{
+					&Assign{"1", &ast.Literal{&types.Type{
+						Kind: 6,
+					}, "2.71828182845904523536028747135266249775724709369995957496696763", nil, nil, "lib/math/constants.ok:1:7"}, ""},
+					&Assign{"E", nil, "1"},
+					&Assign{"2", &ast.Literal{&types.Type{
+						Kind: 6,
+					}, "2.30258509299404568401799145468436420760110148862877297603332790", nil, nil, "lib/math/constants.ok:11:8"}, ""},
+					&Assign{"Ln10", nil, "2"},
+					&Assign{"3", &ast.Literal{&types.Type{
+						Kind: 6,
+					}, "0.693147180559945309417232121458176568075500134360255254120680009", nil, nil, "lib/math/constants.ok:10:8"}, ""},
+					&Assign{"Ln2", nil, "3"},
+					&Assign{"4", &ast.Literal{&types.Type{
+						Kind: 6,
+					}, "1.61803398874989484820458683436563811772030917980576286213544862", nil, nil, "lib/math/constants.ok:3:7"}, ""},
+					&Assign{"Phi", nil, "4"},
+					&Assign{"5", &ast.Literal{&types.Type{
+						Kind: 6,
+					}, "3.14159265358979323846264338327950288419716939937510582097494459", nil, nil, "lib/math/constants.ok:2:7"}, ""},
+					&Assign{"Pi", nil, "5"},
+					&Assign{"6", &ast.Literal{&types.Type{
+						Kind: 6,
+					}, "1.41421356237309504880168872420969807856967187537694807317667974", nil, nil, "lib/math/constants.ok:5:11"}, ""},
+					&Assign{"Sqrt2", nil, "6"},
+					&Assign{"7", &ast.Literal{&types.Type{
+						Kind: 6,
+					}, "1.64872127070012814684865078781416357165377610071014801157507931", nil, nil, "lib/math/constants.ok:6:11"}, ""},
+					&Assign{"SqrtE", nil, "7"},
+					&Assign{"8", &ast.Literal{&types.Type{
+						Kind: 6,
+					}, "1.27201964951406896425242246173749149171560804184009624861664038", nil, nil, "lib/math/constants.ok:8:11"}, ""},
+					&Assign{"SqrtPhi", nil, "8"},
+					&Assign{"9", &ast.Literal{&types.Type{
+						Kind: 6,
+					}, "1.77245385090551602729816748334114518279754945612238712821380779", nil, nil, "lib/math/constants.ok:7:11"}, ""},
+					&Assign{"SqrtPi", nil, "9"},
+					&Assign{"10", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "1", nil, nil, ""}, ""},
+					&ParentScope{"10"},
+					&Assign{"1", nil, "10"},
+					&Assign{"11", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "10", nil, nil, ""}, ""},
+					&ParentScope{"11"},
+					&Assign{"10", nil, "11"},
+					&Assign{"12", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "2", nil, nil, ""}, ""},
+					&ParentScope{"12"},
+					&Assign{"2", nil, "12"},
+					&Assign{"13", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "3", nil, nil, ""}, ""},
+					&ParentScope{"13"},
+					&Assign{"3", nil, "13"},
+					&Assign{"14", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "4", nil, nil, ""}, ""},
+					&ParentScope{"14"},
+					&Assign{"4", nil, "14"},
+					&Assign{"15", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "5", nil, nil, ""}, ""},
+					&ParentScope{"15"},
+					&Assign{"5", nil, "15"},
+					&Assign{"16", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "6", nil, nil, ""}, ""},
+					&ParentScope{"16"},
+					&Assign{"6", nil, "16"},
+					&Assign{"17", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "7", nil, nil, ""}, ""},
+					&ParentScope{"17"},
+					&Assign{"7", nil, "17"},
+					&Assign{"18", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "8", nil, nil, ""}, ""},
+					&ParentScope{"18"},
+					&Assign{"8", nil, "18"},
+					&Assign{"19", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "9", nil, nil, ""}, ""},
+					&ParentScope{"19"},
+					&Assign{"9", nil, "19"},
+					&Assign{"20", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "1", nil, nil, ""}, ""},
+					&ParentScope{"20"},
+					&Assign{"Abs", nil, "20"},
+					&Assign{"21", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "7", nil, nil, ""}, ""},
+					&ParentScope{"21"},
+					&Assign{"Cbrt", nil, "21"},
+					&Assign{"22", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "8", nil, nil, ""}, ""},
+					&ParentScope{"22"},
+					&Assign{"Ceil", nil, "22"},
+					&Assign{"23", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "4", nil, nil, ""}, ""},
+					&ParentScope{"23"},
+					&Assign{"Exp", nil, "23"},
+					&Assign{"24", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "9", nil, nil, ""}, ""},
+					&ParentScope{"24"},
+					&Assign{"Floor", nil, "24"},
+					&Assign{"25", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "3", nil, nil, ""}, ""},
+					&ParentScope{"25"},
+					&Assign{"Log10", nil, "25"},
+					&Assign{"26", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "2", nil, nil, ""}, ""},
+					&ParentScope{"26"},
+					&Assign{"LogE", nil, "26"},
+					&Assign{"27", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "5", nil, nil, ""}, ""},
+					&ParentScope{"27"},
+					&Assign{"Pow", nil, "27"},
+					&Assign{"28", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "10", nil, nil, ""}, ""},
+					&ParentScope{"28"},
+					&Assign{"Round", nil, "28"},
+					&Assign{"29", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "6", nil, nil, ""}, ""},
+					&ParentScope{"29"},
+					&Assign{"Sqrt", nil, "29"},
+					&Return{Registers{"0"}},
+				},
+				Registers: 29,
+				Variables: map[string]*types.Type{
+					"1": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"10": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"2": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"3": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"4": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"5": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"6": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"7": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"8": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"9": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"Abs": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"Cbrt": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"Ceil": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"E": &types.Type{
+						Kind: 6,
+					},
+					"Exp": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"Floor": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"Ln10": &types.Type{
+						Kind: 6,
+					},
+					"Ln2": &types.Type{
+						Kind: 6,
+					},
+					"Log10": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"LogE": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"Phi": &types.Type{
+						Kind: 6,
+					},
+					"Pi": &types.Type{
+						Kind: 6,
+					},
+					"Pow": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"Round": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"Sqrt": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"Sqrt2": &types.Type{
+						Kind: 6,
+					},
+					"SqrtE": &types.Type{
+						Kind: 6,
+					},
+					"SqrtPhi": &types.Type{
+						Kind: 6,
+					},
+					"SqrtPi": &types.Type{
+						Kind: 6,
+					},
+				},
+				Type: &types.Type{
+					Kind: 10,
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 1,
+							Name: "..__math",
+							Properties: map[string]*types.Type{
+								"Abs": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 6,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 6,
+										},
+									},
+								},
+								"Cbrt": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 6,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 6,
+										},
+									},
+								},
+								"Ceil": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 6,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 6,
+										},
+									},
+								},
+								"E": &types.Type{
+									Kind: 6,
+								},
+								"Exp": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 6,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 6,
+										},
+									},
+								},
+								"Floor": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 6,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 6,
+										},
+									},
+								},
+								"Ln10": &types.Type{
+									Kind: 6,
+								},
+								"Ln2": &types.Type{
+									Kind: 6,
+								},
+								"Log10": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 6,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 6,
+										},
+									},
+								},
+								"LogE": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 6,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 6,
+										},
+									},
+								},
+								"Phi": &types.Type{
+									Kind: 6,
+								},
+								"Pi": &types.Type{
+									Kind: 6,
+								},
+								"Pow": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 6,
+										},
+										&types.Type{
+											Kind: 6,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 6,
+										},
+									},
+								},
+								"Round": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 6,
+										},
+										&types.Type{
+											Kind: 6,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 6,
+										},
+									},
+								},
+								"Sqrt": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 6,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 6,
+										},
+									},
+								},
+								"Sqrt2": &types.Type{
+									Kind: 6,
+								},
+								"SqrtE": &types.Type{
+									Kind: 6,
+								},
+								"SqrtPhi": &types.Type{
+									Kind: 6,
+								},
+								"SqrtPi": &types.Type{
+									Kind: 6,
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		"reflect": &File{
 			Imports: nil,
 			Funcs: map[string]*CompiledFunc{
+				"1": &CompiledFunc{
+					Arguments: []string{"fn", "args"},
+					Instructions: []Instruction{
+						&DynamicCall{"fn", "args", "3"},
+						&Return{Registers{"3"}},
+					},
+					Registers: 3,
+					Variables: map[string]*types.Type{
+						"args": &types.Type{
+							Kind: 8,
+							Element: &types.Type{
+								Kind: 2,
+							},
+						},
+						"fn": &types.Type{
+							Kind: 2,
+						},
+					},
+				},
+				"2": &CompiledFunc{
+					Arguments: []string{"obj", "prop"},
+					Instructions: []Instruction{
+						&Get{"obj", "prop", "3"},
+						&Return{Registers{"3"}},
+					},
+					Registers: 3,
+					Variables: map[string]*types.Type{
+						"obj": &types.Type{
+							Kind: 2,
+						},
+						"prop": &types.Type{
+							Kind: 2,
+						},
+					},
+				},
+				"3": &CompiledFunc{
+					Arguments: []string{"value"},
+					Instructions: []Instruction{
+						&Interface{"value", "2"},
+						&Return{Registers{"2"}},
+					},
+					Registers: 2,
+					Variables: map[string]*types.Type{
+						"value": &types.Type{
+							Kind: 2,
+						},
+					},
+				},
+				"4": &CompiledFunc{
+					Arguments: []string{"value"},
+					Instructions: []Instruction{
+						&Assign{"2", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 2,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+						}, "9", nil, nil, ""}, ""},
+						&Call{"*2", Registers{"value"}, Registers{"3"}, &types.Type{
+							Kind: 2,
+						}},
+						&Assign{"type", nil, "3"},
+						&Assign{"4", &ast.Literal{&types.Type{
+							Kind: 7,
+						}, "[]", nil, nil, "lib/reflect/kind.ok:7:30"}, ""},
+						&Assign{"5", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+								&types.Type{
+									Kind: 7,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 3,
+								},
+							},
+						}, "8", nil, nil, ""}, ""},
+						&Call{"*5", Registers{"type", "4"}, Registers{"6"}, &types.Type{
+							Kind: 2,
+						}},
+						&JumpUnless{"6", 9},
+						&Assign{"7", &ast.Literal{&types.Type{
+							Kind: 7,
+						}, "array", nil, nil, "lib/reflect/kind.ok:8:20"}, ""},
+						&Return{Registers{"7"}},
+						&Jump{24},
+						&Assign{"9", &ast.Literal{&types.Type{
+							Kind: 7,
+						}, "{}", nil, nil, "lib/reflect/kind.ok:11:31"}, ""},
+						&Interpolate{"8", Registers{"9"}},
+						&Assign{"10", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+								&types.Type{
+									Kind: 7,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 3,
+								},
+							},
+						}, "8", nil, nil, ""}, ""},
+						&Call{"*10", Registers{"type", "8"}, Registers{"11"}, &types.Type{
+							Kind: 2,
+						}},
+						&JumpUnless{"11", 17},
+						&Assign{"12", &ast.Literal{&types.Type{
+							Kind: 7,
+						}, "map", nil, nil, "lib/reflect/kind.ok:12:20"}, ""},
+						&Return{Registers{"12"}},
+						&Jump{24},
+						&Assign{"13", &ast.Literal{&types.Type{
+							Kind: 7,
+						}, "func(", nil, nil, "lib/reflect/kind.ok:15:30"}, ""},
+						&Assign{"14", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+								&types.Type{
+									Kind: 7,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 3,
+								},
+							},
+						}, "8", nil, nil, ""}, ""},
+						&Call{"*14", Registers{"type", "13"}, Registers{"15"}, &types.Type{
+							Kind: 2,
+						}},
+						&JumpUnless{"15", 24},
+						&Assign{"16", &ast.Literal{&types.Type{
+							Kind: 7,
+						}, "func", nil, nil, "lib/reflect/kind.ok:16:20"}, ""},
+						&Return{Registers{"16"}},
+						&Jump{24},
+						&Return{Registers{"type"}},
+					},
+					Registers: 16,
+					Variables: map[string]*types.Type{
+						"type": &types.Type{
+							Kind: 7,
+						},
+						"value": &types.Type{
+							Kind: 2,
+						},
+					},
+				},
+				"5": &CompiledFunc{
+					Arguments: []string{"value"},
+					Instructions: []Instruction{
+						&Len{"value", "2"},
+						&Return{Registers{"2"}},
+					},
+					Registers: 2,
+					Variables: map[string]*types.Type{
+						"value": &types.Type{
+							Kind: 2,
+						},
+					},
+				},
+				"6": &CompiledFunc{
+					Arguments: []string{"obj"},
+					Instructions: []Instruction{
+						&Props{"obj", "2"},
+						&Return{Registers{"2"}},
+					},
+					Registers: 2,
+					Variables: map[string]*types.Type{
+						"obj": &types.Type{
+							Kind: 2,
+						},
+					},
+				},
+				"7": &CompiledFunc{
+					Arguments: []string{"obj", "prop", "value"},
+					Instructions: []Instruction{
+						&Set{"obj", "prop", "value", "4"},
+						&Return{Registers{"4"}},
+					},
+					Registers: 4,
+					Variables: map[string]*types.Type{
+						"obj": &types.Type{
+							Kind: 2,
+						},
+						"prop": &types.Type{
+							Kind: 2,
+						},
+						"value": &types.Type{
+							Kind: 2,
+						},
+					},
+				},
+				"8": &CompiledFunc{
+					Arguments: []string{"s", "prefix"},
+					Instructions: []Instruction{
+						&Len{"s", "3"},
+						&Len{"prefix", "4"},
+						&LessThanNumber{"3", "4", "5"},
+						&JumpUnless{"5", 5},
+						&Assign{"6", &ast.Literal{&types.Type{
+							Kind: 3,
+						}, "false", nil, nil, "lib/reflect/strings.ok:6:16"}, ""},
+						&Return{Registers{"6"}},
+						&Assign{"7", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "0", nil, nil, "lib/reflect/strings.ok:9:13"}, ""},
+						&Assign{"i", nil, "7"},
+						&Len{"prefix", "8"},
+						&LessThanNumber{"i", "8", "9"},
+						&JumpUnless{"9", 19},
+						&StringIndex{"s", "i", "10"},
+						&StringIndex{"prefix", "i", "11"},
+						&NotEqual{"10", "11", "12"},
+						&JumpUnless{"12", 16},
+						&Assign{"13", &ast.Literal{&types.Type{
+							Kind: 3,
+						}, "false", nil, nil, "lib/reflect/strings.ok:11:20"}, ""},
+						&Return{Registers{"13"}},
+						&Assign{"14", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, ""}, ""},
+						&Add{"i", "14", "i"},
+						&Jump{8},
+						&Assign{"15", &ast.Literal{&types.Type{
+							Kind: 3,
+						}, "true", nil, nil, "lib/reflect/strings.ok:15:12"}, ""},
+						&Return{Registers{"15"}},
+					},
+					Registers: 15,
+					Variables: map[string]*types.Type{
+						"i": &types.Type{
+							Kind: 6,
+						},
+						"prefix": &types.Type{
+							Kind: 7,
+						},
+						"s": &types.Type{
+							Kind: 7,
+						},
+					},
+				},
+				"9": &CompiledFunc{
+					Arguments: []string{"value"},
+					Instructions: []Instruction{
+						&Type{"value", "2"},
+						&Return{Registers{"2"}},
+					},
+					Registers: 2,
+					Variables: map[string]*types.Type{
+						"value": &types.Type{
+							Kind: 2,
+						},
+					},
+				},
 				"Call": &CompiledFunc{
 					Arguments: []string{"fn", "args"},
 					Instructions: []Instruction{
@@ -544,7 +2214,7 @@ func init() {
 									Kind: 7,
 								},
 							},
-						}, "Type", nil, nil, ""}, ""},
+						}, "9", nil, nil, ""}, ""},
 						&Call{"*2", Registers{"value"}, Registers{"3"}, &types.Type{
 							Kind: 2,
 						}},
@@ -567,7 +2237,7 @@ func init() {
 									Kind: 3,
 								},
 							},
-						}, "hasPrefix", nil, nil, ""}, ""},
+						}, "8", nil, nil, ""}, ""},
 						&Call{"*5", Registers{"type", "4"}, Registers{"6"}, &types.Type{
 							Kind: 2,
 						}},
@@ -596,7 +2266,7 @@ func init() {
 									Kind: 3,
 								},
 							},
-						}, "hasPrefix", nil, nil, ""}, ""},
+						}, "8", nil, nil, ""}, ""},
 						&Call{"*10", Registers{"type", "8"}, Registers{"11"}, &types.Type{
 							Kind: 2,
 						}},
@@ -624,7 +2294,7 @@ func init() {
 									Kind: 3,
 								},
 							},
-						}, "hasPrefix", nil, nil, ""}, ""},
+						}, "8", nil, nil, ""}, ""},
 						&Call{"*14", Registers{"type", "13"}, Registers{"15"}, &types.Type{
 							Kind: 2,
 						}},
@@ -755,8 +2425,168 @@ func init() {
 				},
 			},
 			FuncDefs: map[string]*ast.Func{
+				"1": &ast.Func{
+					Name:       "Call",
+					UniqueName: "1",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"fn", &types.Type{
+							Kind: 2,
+						}},
+						&ast.Argument{"args", &types.Type{
+							Kind: 8,
+							Element: &types.Type{
+								Kind: 2,
+							},
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 8,
+							Element: &types.Type{
+								Kind: 2,
+							},
+						},
+					},
+					Pos: "lib/reflect/call.ok:16:1",
+				},
+				"2": &ast.Func{
+					Name:       "Get",
+					UniqueName: "2",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"obj", &types.Type{
+							Kind: 2,
+						}},
+						&ast.Argument{"prop", &types.Type{
+							Kind: 2,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 2,
+						},
+					},
+					Pos: "lib/reflect/get.ok:15:1",
+				},
+				"3": &ast.Func{
+					Name:       "Interface",
+					UniqueName: "3",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"value", &types.Type{
+							Kind: 2,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 7,
+						},
+					},
+					Pos: "lib/reflect/interface.ok:10:1",
+				},
+				"4": &ast.Func{
+					Name:       "Kind",
+					UniqueName: "4",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"value", &types.Type{
+							Kind: 2,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 7,
+						},
+					},
+					Pos: "lib/reflect/kind.ok:3:1",
+				},
+				"5": &ast.Func{
+					Name:       "Len",
+					UniqueName: "5",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"value", &types.Type{
+							Kind: 2,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 6,
+						},
+					},
+					Pos: "lib/reflect/len.ok:3:1",
+				},
+				"6": &ast.Func{
+					Name:       "Properties",
+					UniqueName: "6",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"obj", &types.Type{
+							Kind: 2,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 8,
+							Element: &types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					Pos: "lib/reflect/props.ok:3:1",
+				},
+				"7": &ast.Func{
+					Name:       "Set",
+					UniqueName: "7",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"obj", &types.Type{
+							Kind: 2,
+						}},
+						&ast.Argument{"prop", &types.Type{
+							Kind: 2,
+						}},
+						&ast.Argument{"value", &types.Type{
+							Kind: 2,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 2,
+						},
+					},
+					Pos: "lib/reflect/set.ok:16:1",
+				},
+				"8": &ast.Func{
+					Name:       "hasPrefix",
+					UniqueName: "8",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"s", &types.Type{
+							Kind: 7,
+						}},
+						&ast.Argument{"prefix", &types.Type{
+							Kind: 7,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 3,
+						},
+					},
+					Pos: "lib/reflect/strings.ok:4:1",
+				},
+				"9": &ast.Func{
+					Name:       "Type",
+					UniqueName: "9",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"value", &types.Type{
+							Kind: 2,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 7,
+						},
+					},
+					Pos: "lib/reflect/type.ok:8:1",
+				},
 				"Call": &ast.Func{
-					Name: "Call",
+					Name:       "Call",
+					UniqueName: "1",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"fn", &types.Type{
 							Kind: 2,
@@ -779,7 +2609,8 @@ func init() {
 					Pos: "lib/reflect/call.ok:16:1",
 				},
 				"Get": &ast.Func{
-					Name: "Get",
+					Name:       "Get",
+					UniqueName: "2",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"obj", &types.Type{
 							Kind: 2,
@@ -796,7 +2627,8 @@ func init() {
 					Pos: "lib/reflect/get.ok:15:1",
 				},
 				"Interface": &ast.Func{
-					Name: "Interface",
+					Name:       "Interface",
+					UniqueName: "3",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"value", &types.Type{
 							Kind: 2,
@@ -810,7 +2642,8 @@ func init() {
 					Pos: "lib/reflect/interface.ok:10:1",
 				},
 				"Kind": &ast.Func{
-					Name: "Kind",
+					Name:       "Kind",
+					UniqueName: "4",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"value", &types.Type{
 							Kind: 2,
@@ -824,7 +2657,8 @@ func init() {
 					Pos: "lib/reflect/kind.ok:3:1",
 				},
 				"Len": &ast.Func{
-					Name: "Len",
+					Name:       "Len",
+					UniqueName: "5",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"value", &types.Type{
 							Kind: 2,
@@ -838,7 +2672,8 @@ func init() {
 					Pos: "lib/reflect/len.ok:3:1",
 				},
 				"Properties": &ast.Func{
-					Name: "Properties",
+					Name:       "Properties",
+					UniqueName: "6",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"obj", &types.Type{
 							Kind: 2,
@@ -855,7 +2690,8 @@ func init() {
 					Pos: "lib/reflect/props.ok:3:1",
 				},
 				"Set": &ast.Func{
-					Name: "Set",
+					Name:       "Set",
+					UniqueName: "7",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"obj", &types.Type{
 							Kind: 2,
@@ -875,7 +2711,8 @@ func init() {
 					Pos: "lib/reflect/set.ok:16:1",
 				},
 				"Type": &ast.Func{
-					Name: "Type",
+					Name:       "Type",
+					UniqueName: "9",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"value", &types.Type{
 							Kind: 2,
@@ -889,7 +2726,8 @@ func init() {
 					Pos: "lib/reflect/type.ok:8:1",
 				},
 				"hasPrefix": &ast.Func{
-					Name: "hasPrefix",
+					Name:       "hasPrefix",
+					UniqueName: "8",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"s", &types.Type{
 							Kind: 7,
@@ -907,10 +2745,2297 @@ func init() {
 				},
 			},
 			Constants: nil,
+			PackageFunc: &CompiledFunc{
+				Instructions: []Instruction{
+					&Assign{"1", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+							&types.Type{
+								Kind: 8,
+								Element: &types.Type{
+									Kind: 2,
+								},
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 8,
+								Element: &types.Type{
+									Kind: 2,
+								},
+							},
+						},
+					}, "1", nil, nil, ""}, ""},
+					&ParentScope{"1"},
+					&Assign{"1", nil, "1"},
+					&Assign{"2", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+							&types.Type{
+								Kind: 2,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+						},
+					}, "2", nil, nil, ""}, ""},
+					&ParentScope{"2"},
+					&Assign{"2", nil, "2"},
+					&Assign{"3", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "3", nil, nil, ""}, ""},
+					&ParentScope{"3"},
+					&Assign{"3", nil, "3"},
+					&Assign{"4", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "4", nil, nil, ""}, ""},
+					&ParentScope{"4"},
+					&Assign{"4", nil, "4"},
+					&Assign{"5", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "5", nil, nil, ""}, ""},
+					&ParentScope{"5"},
+					&Assign{"5", nil, "5"},
+					&Assign{"6", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 8,
+								Element: &types.Type{
+									Kind: 7,
+								},
+							},
+						},
+					}, "6", nil, nil, ""}, ""},
+					&ParentScope{"6"},
+					&Assign{"6", nil, "6"},
+					&Assign{"7", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+							&types.Type{
+								Kind: 2,
+							},
+							&types.Type{
+								Kind: 2,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+						},
+					}, "7", nil, nil, ""}, ""},
+					&ParentScope{"7"},
+					&Assign{"7", nil, "7"},
+					&Assign{"8", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 3,
+							},
+						},
+					}, "8", nil, nil, ""}, ""},
+					&ParentScope{"8"},
+					&Assign{"8", nil, "8"},
+					&Assign{"9", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "9", nil, nil, ""}, ""},
+					&ParentScope{"9"},
+					&Assign{"9", nil, "9"},
+					&Assign{"10", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+							&types.Type{
+								Kind: 8,
+								Element: &types.Type{
+									Kind: 2,
+								},
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 8,
+								Element: &types.Type{
+									Kind: 2,
+								},
+							},
+						},
+					}, "1", nil, nil, ""}, ""},
+					&ParentScope{"10"},
+					&Assign{"Call", nil, "10"},
+					&Assign{"11", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+							&types.Type{
+								Kind: 2,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+						},
+					}, "2", nil, nil, ""}, ""},
+					&ParentScope{"11"},
+					&Assign{"Get", nil, "11"},
+					&Assign{"12", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "3", nil, nil, ""}, ""},
+					&ParentScope{"12"},
+					&Assign{"Interface", nil, "12"},
+					&Assign{"13", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "4", nil, nil, ""}, ""},
+					&ParentScope{"13"},
+					&Assign{"Kind", nil, "13"},
+					&Assign{"14", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "5", nil, nil, ""}, ""},
+					&ParentScope{"14"},
+					&Assign{"Len", nil, "14"},
+					&Assign{"15", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 8,
+								Element: &types.Type{
+									Kind: 7,
+								},
+							},
+						},
+					}, "6", nil, nil, ""}, ""},
+					&ParentScope{"15"},
+					&Assign{"Properties", nil, "15"},
+					&Assign{"16", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+							&types.Type{
+								Kind: 2,
+							},
+							&types.Type{
+								Kind: 2,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+						},
+					}, "7", nil, nil, ""}, ""},
+					&ParentScope{"16"},
+					&Assign{"Set", nil, "16"},
+					&Assign{"17", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "9", nil, nil, ""}, ""},
+					&ParentScope{"17"},
+					&Assign{"Type", nil, "17"},
+					&Assign{"18", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 3,
+							},
+						},
+					}, "8", nil, nil, ""}, ""},
+					&ParentScope{"18"},
+					&Assign{"hasPrefix", nil, "18"},
+					&Return{Registers{"0"}},
+				},
+				Registers: 18,
+				Variables: map[string]*types.Type{
+					"1": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+							&types.Type{
+								Kind: 8,
+								Element: &types.Type{
+									Kind: 2,
+								},
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 8,
+								Element: &types.Type{
+									Kind: 2,
+								},
+							},
+						},
+					},
+					"2": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+							&types.Type{
+								Kind: 2,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+						},
+					},
+					"3": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"4": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"5": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"6": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 8,
+								Element: &types.Type{
+									Kind: 7,
+								},
+							},
+						},
+					},
+					"7": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+							&types.Type{
+								Kind: 2,
+							},
+							&types.Type{
+								Kind: 2,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+						},
+					},
+					"8": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 3,
+							},
+						},
+					},
+					"9": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"Call": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+							&types.Type{
+								Kind: 8,
+								Element: &types.Type{
+									Kind: 2,
+								},
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 8,
+								Element: &types.Type{
+									Kind: 2,
+								},
+							},
+						},
+					},
+					"Get": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+							&types.Type{
+								Kind: 2,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+						},
+					},
+					"Interface": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"Kind": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"Len": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"Properties": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 8,
+								Element: &types.Type{
+									Kind: 7,
+								},
+							},
+						},
+					},
+					"Set": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+							&types.Type{
+								Kind: 2,
+							},
+							&types.Type{
+								Kind: 2,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+						},
+					},
+					"Type": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 2,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"hasPrefix": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 3,
+							},
+						},
+					},
+				},
+				Type: &types.Type{
+					Kind: 10,
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 1,
+							Name: "..__reflect",
+							Properties: map[string]*types.Type{
+								"Call": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 2,
+										},
+										&types.Type{
+											Kind: 8,
+											Element: &types.Type{
+												Kind: 2,
+											},
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 8,
+											Element: &types.Type{
+												Kind: 2,
+											},
+										},
+									},
+								},
+								"Get": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 2,
+										},
+										&types.Type{
+											Kind: 2,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 2,
+										},
+									},
+								},
+								"Interface": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 2,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+									},
+								},
+								"Kind": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 2,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+									},
+								},
+								"Len": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 2,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 6,
+										},
+									},
+								},
+								"Properties": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 2,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 8,
+											Element: &types.Type{
+												Kind: 7,
+											},
+										},
+									},
+								},
+								"Set": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 2,
+										},
+										&types.Type{
+											Kind: 2,
+										},
+										&types.Type{
+											Kind: 2,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 2,
+										},
+									},
+								},
+								"Type": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 2,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		"strings": &File{
 			Imports: nil,
 			Funcs: map[string]*CompiledFunc{
+				"1": &CompiledFunc{
+					Arguments: []string{"s"},
+					Instructions: []Instruction{
+						&Assign{"2", &ast.Literal{&types.Type{
+							Kind: 7,
+						}, "", nil, nil, "lib/strings/case.ok:5:14"}, ""},
+						&Assign{"result", nil, "2"},
+						&Assign{"3", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "0", nil, nil, ""}, ""},
+						&NextString{"s", "3", "", "c", "4"},
+						&JumpUnless{"4", 23},
+						&CastNumber{"c", "5"},
+						&Assign{"n", nil, "5"},
+						&Assign{"6", &ast.Literal{&types.Type{
+							Kind: 4,
+						}, "A", nil, nil, "lib/strings/case.ok:8:24"}, ""},
+						&CastNumber{"6", "7"},
+						&GreaterThanEqualNumber{"n", "7", "8"},
+						&Assign{"9", &ast.Literal{&types.Type{
+							Kind: 4,
+						}, "Z", nil, nil, "lib/strings/case.ok:8:44"}, ""},
+						&CastNumber{"9", "10"},
+						&LessThanEqualNumber{"n", "10", "11"},
+						&And{"8", "11", "12"},
+						&JumpUnless{"12", 20},
+						&Assign{"13", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "32", nil, nil, "lib/strings/case.ok:9:40"}, ""},
+						&Add{"n", "13", "14"},
+						&CastChar{"14", "15"},
+						&CastString{"15", "16"},
+						&Concat{"result", "16", "result"},
+						&Jump{22},
+						&CastString{"c", "17"},
+						&Concat{"result", "17", "result"},
+						&Jump{2},
+						&Return{Registers{"result"}},
+					},
+					Registers: 17,
+					Variables: map[string]*types.Type{
+						"c": &types.Type{
+							Kind: 4,
+						},
+						"n": &types.Type{
+							Kind: 6,
+						},
+						"result": &types.Type{
+							Kind: 7,
+						},
+						"s": &types.Type{
+							Kind: 7,
+						},
+					},
+				},
+				"10": &CompiledFunc{
+					Arguments: []string{"s", "substr"},
+					Instructions: []Instruction{
+						&Assign{"3", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+						}, "18", nil, nil, ""}, ""},
+						&Call{"*3", Registers{"s"}, Registers{"4"}, &types.Type{
+							Kind: 2,
+						}},
+						&Assign{"5", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+						}, "18", nil, nil, ""}, ""},
+						&Call{"*5", Registers{"substr"}, Registers{"6"}, &types.Type{
+							Kind: 2,
+						}},
+						&Assign{"7", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+								&types.Type{
+									Kind: 7,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 6,
+								},
+							},
+						}, "6", nil, nil, ""}, ""},
+						&Call{"*7", Registers{"4", "6"}, Registers{"8"}, &types.Type{
+							Kind: 2,
+						}},
+						&Assign{"index", nil, "8"},
+						&Assign{"9", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "-1", nil, nil, "lib/strings/index.ok:59:17"}, ""},
+						&EqualNumber{"index", "9", "10"},
+						&JumpUnless{"10", 11},
+						&Assign{"11", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "-1", nil, nil, "lib/strings/index.ok:60:16"}, ""},
+						&Return{Registers{"11"}},
+						&Len{"s", "12"},
+						&Len{"substr", "13"},
+						&Add{"index", "13", "14"},
+						&Subtract{"12", "14", "15"},
+						&Return{Registers{"15"}},
+					},
+					Registers: 15,
+					Variables: map[string]*types.Type{
+						"index": &types.Type{
+							Kind: 6,
+						},
+						"s": &types.Type{
+							Kind: 7,
+						},
+						"substr": &types.Type{
+							Kind: 7,
+						},
+					},
+				},
+				"11": &CompiledFunc{
+					Arguments: []string{"s", "substr", "offset"},
+					Instructions: []Instruction{
+						&Len{"s", "4"},
+						&Len{"s", "5"},
+						&Assign{"6", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 6,
+								},
+								&types.Type{
+									Kind: 6,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 6,
+								},
+							},
+						}, "8", nil, nil, ""}, ""},
+						&Call{"*6", Registers{"offset", "5"}, Registers{"7"}, &types.Type{
+							Kind: 2,
+						}},
+						&Assign{"8", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, "lib/strings/index.ok:79:45"}, ""},
+						&Add{"7", "8", "9"},
+						&Subtract{"4", "9", "10"},
+						&Assign{"offset", nil, "10"},
+						&Assign{"11", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+						}, "18", nil, nil, ""}, ""},
+						&Call{"*11", Registers{"s"}, Registers{"12"}, &types.Type{
+							Kind: 2,
+						}},
+						&Assign{"13", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+						}, "18", nil, nil, ""}, ""},
+						&Call{"*13", Registers{"substr"}, Registers{"14"}, &types.Type{
+							Kind: 2,
+						}},
+						&Assign{"15", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+								&types.Type{
+									Kind: 7,
+								},
+								&types.Type{
+									Kind: 6,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 6,
+								},
+							},
+						}, "7", nil, nil, ""}, ""},
+						&Call{"*15", Registers{"12", "14", "offset"}, Registers{"16"}, &types.Type{
+							Kind: 2,
+						}},
+						&Assign{"index", nil, "16"},
+						&Assign{"17", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "-1", nil, nil, "lib/strings/index.ok:82:17"}, ""},
+						&EqualNumber{"index", "17", "18"},
+						&JumpUnless{"18", 19},
+						&Assign{"19", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "-1", nil, nil, "lib/strings/index.ok:83:16"}, ""},
+						&Return{Registers{"19"}},
+						&Len{"s", "20"},
+						&Len{"substr", "21"},
+						&Add{"index", "21", "22"},
+						&Subtract{"20", "22", "23"},
+						&Return{Registers{"23"}},
+					},
+					Registers: 23,
+					Variables: map[string]*types.Type{
+						"index": &types.Type{
+							Kind: 6,
+						},
+						"offset": &types.Type{
+							Kind: 6,
+						},
+						"s": &types.Type{
+							Kind: 7,
+						},
+						"substr": &types.Type{
+							Kind: 7,
+						},
+					},
+				},
+				"12": &CompiledFunc{
+					Arguments: []string{"strings", "glue"},
+					Instructions: []Instruction{
+						&Assign{"3", &ast.Literal{&types.Type{
+							Kind: 7,
+						}, "", nil, nil, "lib/strings/join.ok:5:14"}, ""},
+						&Assign{"result", nil, "3"},
+						&Assign{"4", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "0", nil, nil, ""}, ""},
+						&NextArray{"strings", "4", "i", "s", "5"},
+						&JumpUnless{"5", 10},
+						&Assign{"6", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "0", nil, nil, "lib/strings/join.ok:7:16"}, ""},
+						&GreaterThanNumber{"i", "6", "7"},
+						&JumpUnless{"7", 8},
+						&Concat{"result", "glue", "result"},
+						&Concat{"result", "s", "result"},
+						&Jump{2},
+						&Return{Registers{"result"}},
+					},
+					Registers: 7,
+					Variables: map[string]*types.Type{
+						"glue": &types.Type{
+							Kind: 7,
+						},
+						"i": &types.Type{
+							Kind: 6,
+						},
+						"result": &types.Type{
+							Kind: 7,
+						},
+						"s": &types.Type{
+							Kind: 7,
+						},
+						"strings": &types.Type{
+							Kind: 8,
+							Element: &types.Type{
+								Kind: 7,
+							},
+						},
+					},
+				},
+				"13": &CompiledFunc{
+					Arguments: []string{"s", "pad", "toLen"},
+					Instructions: []Instruction{
+						&Len{"s", "4"},
+						&GreaterThanEqualNumber{"4", "toLen", "5"},
+						&Assign{"6", &ast.Literal{&types.Type{
+							Kind: 7,
+						}, "", nil, nil, "lib/strings/pad.ok:10:34"}, ""},
+						&Equal{"pad", "6", "7"},
+						&Or{"5", "7", "8"},
+						&JumpUnless{"8", 6},
+						&Return{Registers{"s"}},
+						&Len{"s", "9"},
+						&Subtract{"toLen", "9", "10"},
+						&Assign{"11", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+								&types.Type{
+									Kind: 6,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+						}, "15", nil, nil, ""}, ""},
+						&Call{"*11", Registers{"pad", "10"}, Registers{"12"}, &types.Type{
+							Kind: 2,
+						}},
+						&Concat{"12", "s", "13"},
+						&Return{Registers{"13"}},
+					},
+					Registers: 13,
+					Variables: map[string]*types.Type{
+						"pad": &types.Type{
+							Kind: 7,
+						},
+						"s": &types.Type{
+							Kind: 7,
+						},
+						"toLen": &types.Type{
+							Kind: 6,
+						},
+					},
+				},
+				"14": &CompiledFunc{
+					Arguments: []string{"s", "pad", "toLen"},
+					Instructions: []Instruction{
+						&Len{"s", "4"},
+						&GreaterThanEqualNumber{"4", "toLen", "5"},
+						&Assign{"6", &ast.Literal{&types.Type{
+							Kind: 7,
+						}, "", nil, nil, "lib/strings/pad.ok:20:34"}, ""},
+						&Equal{"pad", "6", "7"},
+						&Or{"5", "7", "8"},
+						&JumpUnless{"8", 6},
+						&Return{Registers{"s"}},
+						&Len{"s", "9"},
+						&Subtract{"toLen", "9", "10"},
+						&Assign{"11", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+								&types.Type{
+									Kind: 6,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+						}, "15", nil, nil, ""}, ""},
+						&Call{"*11", Registers{"pad", "10"}, Registers{"12"}, &types.Type{
+							Kind: 2,
+						}},
+						&Concat{"s", "12", "13"},
+						&Return{Registers{"13"}},
+					},
+					Registers: 13,
+					Variables: map[string]*types.Type{
+						"pad": &types.Type{
+							Kind: 7,
+						},
+						"s": &types.Type{
+							Kind: 7,
+						},
+						"toLen": &types.Type{
+							Kind: 6,
+						},
+					},
+				},
+				"15": &CompiledFunc{
+					Arguments: []string{"pad", "toLen"},
+					Instructions: []Instruction{
+						&Len{"pad", "3"},
+						&Divide{"toLen", "3", "4"},
+						&Assign{"5", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+								&types.Type{
+									Kind: 6,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+						}, "16", nil, nil, ""}, ""},
+						&Call{"*5", Registers{"pad", "4"}, Registers{"6"}, &types.Type{
+							Kind: 2,
+						}},
+						&Assign{"7", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "0", nil, nil, "lib/strings/pad.ok:28:50"}, ""},
+						&Assign{"8", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+								&types.Type{
+									Kind: 6,
+								},
+								&types.Type{
+									Kind: 6,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+						}, "20", nil, nil, ""}, ""},
+						&Call{"*8", Registers{"6", "7", "toLen"}, Registers{"9"}, &types.Type{
+							Kind: 2,
+						}},
+						&Return{Registers{"9"}},
+					},
+					Registers: 9,
+					Variables: map[string]*types.Type{
+						"pad": &types.Type{
+							Kind: 7,
+						},
+						"toLen": &types.Type{
+							Kind: 6,
+						},
+					},
+				},
+				"16": &CompiledFunc{
+					Arguments: []string{"str", "times"},
+					Instructions: []Instruction{
+						&Assign{"3", &ast.Literal{&types.Type{
+							Kind: 7,
+						}, "", nil, nil, "lib/strings/repeat.ok:4:14"}, ""},
+						&Assign{"result", nil, "3"},
+						&Assign{"4", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "0", nil, nil, "lib/strings/repeat.ok:5:13"}, ""},
+						&Assign{"i", nil, "4"},
+						&LessThanNumber{"i", "times", "5"},
+						&JumpUnless{"5", 9},
+						&Concat{"result", "str", "result"},
+						&Assign{"6", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, ""}, ""},
+						&Add{"i", "6", "i"},
+						&Jump{3},
+						&Return{Registers{"result"}},
+					},
+					Registers: 6,
+					Variables: map[string]*types.Type{
+						"i": &types.Type{
+							Kind: 6,
+						},
+						"result": &types.Type{
+							Kind: 7,
+						},
+						"str": &types.Type{
+							Kind: 7,
+						},
+						"times": &types.Type{
+							Kind: 6,
+						},
+					},
+				},
+				"17": &CompiledFunc{
+					Arguments: []string{"s", "find", "replace"},
+					Instructions: []Instruction{
+						&Assign{"4", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+								&types.Type{
+									Kind: 7,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 8,
+									Element: &types.Type{
+										Kind: 7,
+									},
+								},
+							},
+						}, "19", nil, nil, ""}, ""},
+						&Call{"*4", Registers{"s", "find"}, Registers{"5"}, &types.Type{
+							Kind: 2,
+						}},
+						&Assign{"6", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 8,
+									Element: &types.Type{
+										Kind: 7,
+									},
+								},
+								&types.Type{
+									Kind: 7,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+						}, "12", nil, nil, ""}, ""},
+						&Call{"*6", Registers{"5", "replace"}, Registers{"7"}, &types.Type{
+							Kind: 2,
+						}},
+						&Return{Registers{"7"}},
+					},
+					Registers: 7,
+					Variables: map[string]*types.Type{
+						"find": &types.Type{
+							Kind: 7,
+						},
+						"replace": &types.Type{
+							Kind: 7,
+						},
+						"s": &types.Type{
+							Kind: 7,
+						},
+					},
+				},
+				"18": &CompiledFunc{
+					Arguments: []string{"s"},
+					Instructions: []Instruction{
+						&Assign{"2", &ast.Literal{&types.Type{
+							Kind: 7,
+						}, "", nil, nil, "lib/strings/reverse.ok:3:14"}, ""},
+						&Assign{"result", nil, "2"},
+						&Len{"s", "3"},
+						&Assign{"4", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, "lib/strings/reverse.ok:4:22"}, ""},
+						&Subtract{"3", "4", "5"},
+						&Assign{"i", nil, "5"},
+						&Assign{"6", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "0", nil, nil, "lib/strings/reverse.ok:4:30"}, ""},
+						&GreaterThanEqualNumber{"i", "6", "7"},
+						&JumpUnless{"7", 14},
+						&StringIndex{"s", "i", "8"},
+						&CastString{"8", "9"},
+						&Concat{"result", "9", "result"},
+						&Assign{"10", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, ""}, ""},
+						&Subtract{"i", "10", "i"},
+						&Jump{6},
+						&Return{Registers{"result"}},
+					},
+					Registers: 10,
+					Variables: map[string]*types.Type{
+						"i": &types.Type{
+							Kind: 6,
+						},
+						"result": &types.Type{
+							Kind: 7,
+						},
+						"s": &types.Type{
+							Kind: 7,
+						},
+					},
+				},
+				"19": &CompiledFunc{
+					Arguments: []string{"s", "delimiter"},
+					Instructions: []Instruction{
+						&Assign{"3", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "0", nil, nil, ""}, ""},
+						&ArrayAlloc{"3", "4", &types.Type{
+							Kind: 8,
+							Element: &types.Type{
+								Kind: 7,
+							},
+						}},
+						&Assign{"elements", nil, "4"},
+						&Assign{"5", &ast.Literal{&types.Type{
+							Kind: 7,
+						}, "", nil, nil, "lib/strings/split.ok:10:21"}, ""},
+						&Equal{"delimiter", "5", "6"},
+						&JumpUnless{"6", 21},
+						&Assign{"7", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "0", nil, nil, "lib/strings/split.ok:13:17"}, ""},
+						&Assign{"i", nil, "7"},
+						&Len{"s", "8"},
+						&LessThanNumber{"i", "8", "9"},
+						&JumpUnless{"9", 20},
+						&Assign{"10", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, ""}, ""},
+						&ArrayAlloc{"10", "11", &types.Type{
+							Kind: 8,
+							Element: &types.Type{
+								Kind: 7,
+							},
+						}},
+						&Assign{"12", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "0", nil, nil, ""}, ""},
+						&StringIndex{"s", "i", "13"},
+						&CastString{"13", "14"},
+						&ArraySet{"11", "12", "14"},
+						&Append{"elements", "11", "elements"},
+						&Assign{"15", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, ""}, ""},
+						&Add{"i", "15", "i"},
+						&Jump{8},
+						&Jump{59},
+						&Assign{"16", &ast.Literal{&types.Type{
+							Kind: 7,
+						}, "", nil, nil, "lib/strings/split.ok:17:19"}, ""},
+						&Assign{"element", nil, "16"},
+						&Assign{"17", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "0", nil, nil, "lib/strings/split.ok:18:17"}, ""},
+						&Assign{"i", nil, "17"},
+						&Len{"s", "18"},
+						&LessThanNumber{"i", "18", "19"},
+						&JumpUnless{"19", 54},
+						&Assign{"20", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, "lib/strings/split.ok:19:45"}, ""},
+						&Subtract{"i", "20", "21"},
+						&Assign{"22", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+								&types.Type{
+									Kind: 7,
+								},
+								&types.Type{
+									Kind: 6,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 6,
+								},
+							},
+						}, "7", nil, nil, ""}, ""},
+						&Call{"*22", Registers{"s", "delimiter", "21"}, Registers{"23"}, &types.Type{
+							Kind: 2,
+						}},
+						&Subtract{"23", "i", "24"},
+						&Assign{"25", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "0", nil, nil, "lib/strings/split.ok:19:55"}, ""},
+						&EqualNumber{"24", "25", "26"},
+						&JumpUnless{"26", 48},
+						&Assign{"27", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, ""}, ""},
+						&ArrayAlloc{"27", "28", &types.Type{
+							Kind: 8,
+							Element: &types.Type{
+								Kind: 7,
+							},
+						}},
+						&Assign{"29", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "0", nil, nil, ""}, ""},
+						&ArraySet{"28", "29", "element"},
+						&Append{"elements", "28", "elements"},
+						&Assign{"30", &ast.Literal{&types.Type{
+							Kind: 7,
+						}, "", nil, nil, "lib/strings/split.ok:21:27"}, ""},
+						&Assign{"element", nil, "30"},
+						&Len{"delimiter", "31"},
+						&Assign{"32", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, "lib/strings/split.ok:22:39"}, ""},
+						&Subtract{"31", "32", "33"},
+						&Add{"i", "33", "i"},
+						&Jump{51},
+						&StringIndex{"s", "i", "34"},
+						&CastString{"34", "35"},
+						&Concat{"element", "35", "element"},
+						&Assign{"36", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, ""}, ""},
+						&Add{"i", "36", "i"},
+						&Jump{26},
+						&Assign{"37", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, ""}, ""},
+						&ArrayAlloc{"37", "38", &types.Type{
+							Kind: 8,
+							Element: &types.Type{
+								Kind: 7,
+							},
+						}},
+						&Assign{"39", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "0", nil, nil, ""}, ""},
+						&ArraySet{"38", "39", "element"},
+						&Append{"elements", "38", "elements"},
+						&Return{Registers{"elements"}},
+					},
+					Registers: 39,
+					Variables: map[string]*types.Type{
+						"delimiter": &types.Type{
+							Kind: 7,
+						},
+						"element": &types.Type{
+							Kind: 7,
+						},
+						"elements": &types.Type{
+							Kind: 8,
+							Element: &types.Type{
+								Kind: 7,
+							},
+						},
+						"i": &types.Type{
+							Kind: 6,
+						},
+						"s": &types.Type{
+							Kind: 7,
+						},
+					},
+				},
+				"2": &CompiledFunc{
+					Arguments: []string{"s"},
+					Instructions: []Instruction{
+						&Assign{"2", &ast.Literal{&types.Type{
+							Kind: 7,
+						}, "", nil, nil, "lib/strings/case.ok:22:14"}, ""},
+						&Assign{"result", nil, "2"},
+						&Assign{"3", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "0", nil, nil, ""}, ""},
+						&NextString{"s", "3", "", "c", "4"},
+						&JumpUnless{"4", 23},
+						&CastNumber{"c", "5"},
+						&Assign{"n", nil, "5"},
+						&Assign{"6", &ast.Literal{&types.Type{
+							Kind: 4,
+						}, "a", nil, nil, "lib/strings/case.ok:25:24"}, ""},
+						&CastNumber{"6", "7"},
+						&GreaterThanEqualNumber{"n", "7", "8"},
+						&Assign{"9", &ast.Literal{&types.Type{
+							Kind: 4,
+						}, "z", nil, nil, "lib/strings/case.ok:25:44"}, ""},
+						&CastNumber{"9", "10"},
+						&LessThanEqualNumber{"n", "10", "11"},
+						&And{"8", "11", "12"},
+						&JumpUnless{"12", 20},
+						&Assign{"13", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "32", nil, nil, "lib/strings/case.ok:26:40"}, ""},
+						&Subtract{"n", "13", "14"},
+						&CastChar{"14", "15"},
+						&CastString{"15", "16"},
+						&Concat{"result", "16", "result"},
+						&Jump{22},
+						&CastString{"c", "17"},
+						&Concat{"result", "17", "result"},
+						&Jump{2},
+						&Return{Registers{"result"}},
+					},
+					Registers: 17,
+					Variables: map[string]*types.Type{
+						"c": &types.Type{
+							Kind: 4,
+						},
+						"n": &types.Type{
+							Kind: 6,
+						},
+						"result": &types.Type{
+							Kind: 7,
+						},
+						"s": &types.Type{
+							Kind: 7,
+						},
+					},
+				},
+				"20": &CompiledFunc{
+					Arguments: []string{"s", "fromIndex", "toIndex"},
+					Instructions: []Instruction{
+						&Assign{"4", &ast.Literal{&types.Type{
+							Kind: 7,
+						}, "", nil, nil, "lib/strings/substr.ok:4:9"}, ""},
+						&Assign{"r", nil, "4"},
+						&Assign{"i", nil, "fromIndex"},
+						&LessThanNumber{"i", "toIndex", "5"},
+						&JumpUnless{"5", 10},
+						&StringIndex{"s", "i", "6"},
+						&CastString{"6", "7"},
+						&Concat{"r", "7", "r"},
+						&Assign{"8", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, ""}, ""},
+						&Add{"i", "8", "i"},
+						&Jump{2},
+						&Return{Registers{"r"}},
+					},
+					Registers: 8,
+					Variables: map[string]*types.Type{
+						"fromIndex": &types.Type{
+							Kind: 6,
+						},
+						"i": &types.Type{
+							Kind: 6,
+						},
+						"r": &types.Type{
+							Kind: 7,
+						},
+						"s": &types.Type{
+							Kind: 7,
+						},
+						"toIndex": &types.Type{
+							Kind: 6,
+						},
+					},
+				},
+				"21": &CompiledFunc{
+					Arguments: []string{"s", "cutset"},
+					Instructions: []Instruction{
+						&Assign{"3", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "0", nil, nil, "lib/strings/trim.ok:4:18"}, ""},
+						&Assign{"offset", nil, "3"},
+						&Len{"s", "4"},
+						&LessThanNumber{"offset", "4", "5"},
+						&JumpUnless{"5", 17},
+						&StringIndex{"s", "offset", "6"},
+						&CastString{"6", "7"},
+						&Assign{"8", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+								&types.Type{
+									Kind: 7,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 6,
+								},
+							},
+						}, "6", nil, nil, ""}, ""},
+						&Call{"*8", Registers{"cutset", "7"}, Registers{"9"}, &types.Type{
+							Kind: 2,
+						}},
+						&Assign{"10", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "-1", nil, nil, "lib/strings/trim.ok:5:47"}, ""},
+						&EqualNumber{"9", "10", "11"},
+						&JumpUnless{"11", 14},
+						&Assign{"12", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+								&types.Type{
+									Kind: 6,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+						}, "26", nil, nil, ""}, ""},
+						&Call{"*12", Registers{"s", "offset"}, Registers{"13"}, &types.Type{
+							Kind: 2,
+						}},
+						&Return{Registers{"13"}},
+						&Assign{"14", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, ""}, ""},
+						&Add{"offset", "14", "offset"},
+						&Jump{2},
+						&Return{Registers{"s"}},
+					},
+					Registers: 14,
+					Variables: map[string]*types.Type{
+						"cutset": &types.Type{
+							Kind: 7,
+						},
+						"offset": &types.Type{
+							Kind: 6,
+						},
+						"s": &types.Type{
+							Kind: 7,
+						},
+					},
+				},
+				"22": &CompiledFunc{
+					Arguments: []string{"s", "cutset"},
+					Instructions: []Instruction{
+						&Assign{"3", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+						}, "18", nil, nil, ""}, ""},
+						&Call{"*3", Registers{"s"}, Registers{"4"}, &types.Type{
+							Kind: 2,
+						}},
+						&Assign{"5", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+								&types.Type{
+									Kind: 7,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+						}, "21", nil, nil, ""}, ""},
+						&Call{"*5", Registers{"4", "cutset"}, Registers{"6"}, &types.Type{
+							Kind: 2,
+						}},
+						&Assign{"7", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+						}, "18", nil, nil, ""}, ""},
+						&Call{"*7", Registers{"6"}, Registers{"8"}, &types.Type{
+							Kind: 2,
+						}},
+						&Return{Registers{"8"}},
+					},
+					Registers: 8,
+					Variables: map[string]*types.Type{
+						"cutset": &types.Type{
+							Kind: 7,
+						},
+						"s": &types.Type{
+							Kind: 7,
+						},
+					},
+				},
+				"23": &CompiledFunc{
+					Arguments: []string{"s", "cutset"},
+					Instructions: []Instruction{
+						&Assign{"3", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+								&types.Type{
+									Kind: 7,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+						}, "21", nil, nil, ""}, ""},
+						&Call{"*3", Registers{"s", "cutset"}, Registers{"4"}, &types.Type{
+							Kind: 2,
+						}},
+						&Assign{"5", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+								&types.Type{
+									Kind: 7,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+						}, "22", nil, nil, ""}, ""},
+						&Call{"*5", Registers{"4", "cutset"}, Registers{"6"}, &types.Type{
+							Kind: 2,
+						}},
+						&Return{Registers{"6"}},
+					},
+					Registers: 6,
+					Variables: map[string]*types.Type{
+						"cutset": &types.Type{
+							Kind: 7,
+						},
+						"s": &types.Type{
+							Kind: 7,
+						},
+					},
+				},
+				"24": &CompiledFunc{
+					Arguments: []string{"s", "prefix"},
+					Instructions: []Instruction{
+						&Assign{"3", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+								&types.Type{
+									Kind: 7,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 3,
+								},
+							},
+						}, "4", nil, nil, ""}, ""},
+						&Call{"*3", Registers{"s", "prefix"}, Registers{"4"}, &types.Type{
+							Kind: 2,
+						}},
+						&JumpUnless{"4", 6},
+						&Len{"prefix", "5"},
+						&Assign{"6", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+								&types.Type{
+									Kind: 6,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+						}, "26", nil, nil, ""}, ""},
+						&Call{"*6", Registers{"s", "5"}, Registers{"7"}, &types.Type{
+							Kind: 2,
+						}},
+						&Return{Registers{"7"}},
+						&Return{Registers{"s"}},
+					},
+					Registers: 7,
+					Variables: map[string]*types.Type{
+						"prefix": &types.Type{
+							Kind: 7,
+						},
+						"s": &types.Type{
+							Kind: 7,
+						},
+					},
+				},
+				"25": &CompiledFunc{
+					Arguments: []string{"s", "suffix"},
+					Instructions: []Instruction{
+						&Assign{"3", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+						}, "18", nil, nil, ""}, ""},
+						&Call{"*3", Registers{"s"}, Registers{"4"}, &types.Type{
+							Kind: 2,
+						}},
+						&Assign{"5", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+						}, "18", nil, nil, ""}, ""},
+						&Call{"*5", Registers{"suffix"}, Registers{"6"}, &types.Type{
+							Kind: 2,
+						}},
+						&Assign{"7", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+								&types.Type{
+									Kind: 7,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+						}, "24", nil, nil, ""}, ""},
+						&Call{"*7", Registers{"4", "6"}, Registers{"8"}, &types.Type{
+							Kind: 2,
+						}},
+						&Assign{"9", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+							},
+						}, "18", nil, nil, ""}, ""},
+						&Call{"*9", Registers{"8"}, Registers{"10"}, &types.Type{
+							Kind: 2,
+						}},
+						&Return{Registers{"10"}},
+					},
+					Registers: 10,
+					Variables: map[string]*types.Type{
+						"s": &types.Type{
+							Kind: 7,
+						},
+						"suffix": &types.Type{
+							Kind: 7,
+						},
+					},
+				},
+				"26": &CompiledFunc{
+					Arguments: []string{"s", "index"},
+					Instructions: []Instruction{
+						&Assign{"3", &ast.Literal{&types.Type{
+							Kind: 7,
+						}, "", nil, nil, "lib/strings/trim.ok:53:14"}, ""},
+						&Assign{"result", nil, "3"},
+						&Len{"s", "4"},
+						&LessThanNumber{"index", "4", "5"},
+						&JumpUnless{"5", 10},
+						&StringIndex{"s", "index", "6"},
+						&CastString{"6", "7"},
+						&Concat{"result", "7", "result"},
+						&Assign{"8", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, ""}, ""},
+						&Add{"index", "8", "index"},
+						&Jump{2},
+						&Return{Registers{"result"}},
+					},
+					Registers: 8,
+					Variables: map[string]*types.Type{
+						"index": &types.Type{
+							Kind: 6,
+						},
+						"result": &types.Type{
+							Kind: 7,
+						},
+						"s": &types.Type{
+							Kind: 7,
+						},
+					},
+				},
+				"3": &CompiledFunc{
+					Arguments: []string{"s", "substr"},
+					Instructions: []Instruction{
+						&Assign{"3", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+								&types.Type{
+									Kind: 7,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 6,
+								},
+							},
+						}, "6", nil, nil, ""}, ""},
+						&Call{"*3", Registers{"s", "substr"}, Registers{"4"}, &types.Type{
+							Kind: 2,
+						}},
+						&Assign{"5", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "-1", nil, nil, "lib/strings/contains.ok:3:32"}, ""},
+						&NotEqualNumber{"4", "5", "6"},
+						&Return{Registers{"6"}},
+					},
+					Registers: 6,
+					Variables: map[string]*types.Type{
+						"s": &types.Type{
+							Kind: 7,
+						},
+						"substr": &types.Type{
+							Kind: 7,
+						},
+					},
+				},
+				"4": &CompiledFunc{
+					Arguments: []string{"s", "prefix"},
+					Instructions: []Instruction{
+						&Len{"s", "3"},
+						&Len{"prefix", "4"},
+						&LessThanNumber{"3", "4", "5"},
+						&JumpUnless{"5", 5},
+						&Assign{"6", &ast.Literal{&types.Type{
+							Kind: 3,
+						}, "false", nil, nil, "lib/strings/contains.ok:9:16"}, ""},
+						&Return{Registers{"6"}},
+						&Assign{"7", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "0", nil, nil, "lib/strings/contains.ok:12:13"}, ""},
+						&Assign{"i", nil, "7"},
+						&Len{"prefix", "8"},
+						&LessThanNumber{"i", "8", "9"},
+						&JumpUnless{"9", 19},
+						&StringIndex{"s", "i", "10"},
+						&StringIndex{"prefix", "i", "11"},
+						&NotEqual{"10", "11", "12"},
+						&JumpUnless{"12", 16},
+						&Assign{"13", &ast.Literal{&types.Type{
+							Kind: 3,
+						}, "false", nil, nil, "lib/strings/contains.ok:14:20"}, ""},
+						&Return{Registers{"13"}},
+						&Assign{"14", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, ""}, ""},
+						&Add{"i", "14", "i"},
+						&Jump{8},
+						&Assign{"15", &ast.Literal{&types.Type{
+							Kind: 3,
+						}, "true", nil, nil, "lib/strings/contains.ok:18:12"}, ""},
+						&Return{Registers{"15"}},
+					},
+					Registers: 15,
+					Variables: map[string]*types.Type{
+						"i": &types.Type{
+							Kind: 6,
+						},
+						"prefix": &types.Type{
+							Kind: 7,
+						},
+						"s": &types.Type{
+							Kind: 7,
+						},
+					},
+				},
+				"5": &CompiledFunc{
+					Arguments: []string{"s", "suffix"},
+					Instructions: []Instruction{
+						&Len{"s", "3"},
+						&Len{"suffix", "4"},
+						&LessThanNumber{"3", "4", "5"},
+						&JumpUnless{"5", 5},
+						&Assign{"6", &ast.Literal{&types.Type{
+							Kind: 3,
+						}, "false", nil, nil, "lib/strings/contains.ok:24:16"}, ""},
+						&Return{Registers{"6"}},
+						&Len{"s", "7"},
+						&Assign{"8", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, "lib/strings/contains.ok:27:18"}, ""},
+						&Subtract{"7", "8", "9"},
+						&Assign{"j", nil, "9"},
+						&Len{"suffix", "10"},
+						&Assign{"11", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, "lib/strings/contains.ok:28:27"}, ""},
+						&Subtract{"10", "11", "12"},
+						&Assign{"i", nil, "12"},
+						&Assign{"13", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "0", nil, nil, "lib/strings/contains.ok:28:35"}, ""},
+						&GreaterThanEqualNumber{"i", "13", "14"},
+						&JumpUnless{"14", 27},
+						&StringIndex{"s", "j", "15"},
+						&StringIndex{"suffix", "i", "16"},
+						&NotEqual{"15", "16", "17"},
+						&JumpUnless{"17", 22},
+						&Assign{"18", &ast.Literal{&types.Type{
+							Kind: 3,
+						}, "false", nil, nil, "lib/strings/contains.ok:30:20"}, ""},
+						&Return{Registers{"18"}},
+						&Assign{"19", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, ""}, ""},
+						&Subtract{"j", "19", "j"},
+						&Assign{"20", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, ""}, ""},
+						&Subtract{"i", "20", "i"},
+						&Jump{14},
+						&Assign{"21", &ast.Literal{&types.Type{
+							Kind: 3,
+						}, "true", nil, nil, "lib/strings/contains.ok:36:12"}, ""},
+						&Return{Registers{"21"}},
+					},
+					Registers: 21,
+					Variables: map[string]*types.Type{
+						"i": &types.Type{
+							Kind: 6,
+						},
+						"j": &types.Type{
+							Kind: 6,
+						},
+						"s": &types.Type{
+							Kind: 7,
+						},
+						"suffix": &types.Type{
+							Kind: 7,
+						},
+					},
+				},
+				"6": &CompiledFunc{
+					Arguments: []string{"s", "substr"},
+					Instructions: []Instruction{
+						&Assign{"3", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "-1", nil, nil, "lib/strings/index.ok:3:34"}, ""},
+						&Assign{"4", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 7,
+								},
+								&types.Type{
+									Kind: 7,
+								},
+								&types.Type{
+									Kind: 6,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 6,
+								},
+							},
+						}, "7", nil, nil, ""}, ""},
+						&Call{"*4", Registers{"s", "substr", "3"}, Registers{"5"}, &types.Type{
+							Kind: 2,
+						}},
+						&Return{Registers{"5"}},
+					},
+					Registers: 5,
+					Variables: map[string]*types.Type{
+						"s": &types.Type{
+							Kind: 7,
+						},
+						"substr": &types.Type{
+							Kind: 7,
+						},
+					},
+				},
+				"7": &CompiledFunc{
+					Arguments: []string{"s", "substr", "offset"},
+					Instructions: []Instruction{
+						&Assign{"4", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "-1", nil, nil, "lib/strings/index.ok:18:26"}, ""},
+						&Assign{"5", &ast.Literal{&types.Type{
+							Kind: 10,
+							Arguments: []*types.Type{
+								&types.Type{
+									Kind: 6,
+								},
+								&types.Type{
+									Kind: 6,
+								},
+							},
+							Returns: []*types.Type{
+								&types.Type{
+									Kind: 6,
+								},
+							},
+						}, "9", nil, nil, ""}, ""},
+						&Call{"*5", Registers{"offset", "4"}, Registers{"6"}, &types.Type{
+							Kind: 2,
+						}},
+						&Assign{"offset", nil, "6"},
+						&Assign{"7", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, "lib/strings/index.ok:20:22"}, ""},
+						&Add{"offset", "7", "8"},
+						&Assign{"i", nil, "8"},
+						&Len{"s", "9"},
+						&Len{"substr", "10"},
+						&Subtract{"9", "10", "11"},
+						&LessThanEqualNumber{"i", "11", "12"},
+						&JumpUnless{"12", 34},
+						&Assign{"13", &ast.Literal{&types.Type{
+							Kind: 3,
+						}, "true", nil, nil, "lib/strings/index.ok:21:17"}, ""},
+						&Assign{"found", nil, "13"},
+						&Assign{"14", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "0", nil, nil, "lib/strings/index.ok:23:17"}, ""},
+						&Assign{"j", nil, "14"},
+						&Len{"substr", "15"},
+						&LessThanNumber{"j", "15", "16"},
+						&JumpUnless{"16", 29},
+						&Add{"i", "j", "17"},
+						&StringIndex{"s", "17", "18"},
+						&StringIndex{"substr", "j", "19"},
+						&NotEqual{"18", "19", "20"},
+						&JumpUnless{"20", 26},
+						&Assign{"21", &ast.Literal{&types.Type{
+							Kind: 3,
+						}, "false", nil, nil, "lib/strings/index.ok:25:25"}, ""},
+						&Assign{"found", nil, "21"},
+						&Jump{29},
+						&Assign{"22", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, ""}, ""},
+						&Add{"j", "22", "j"},
+						&Jump{16},
+						&JumpUnless{"found", 31},
+						&Return{Registers{"i"}},
+						&Assign{"23", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "1", nil, nil, ""}, ""},
+						&Add{"i", "23", "i"},
+						&Jump{9},
+						&Assign{"24", &ast.Literal{&types.Type{
+							Kind: 6,
+						}, "-1", nil, nil, "lib/strings/index.ok:35:12"}, ""},
+						&Return{Registers{"24"}},
+					},
+					Registers: 24,
+					Variables: map[string]*types.Type{
+						"found": &types.Type{
+							Kind: 3,
+						},
+						"i": &types.Type{
+							Kind: 6,
+						},
+						"j": &types.Type{
+							Kind: 6,
+						},
+						"offset": &types.Type{
+							Kind: 6,
+						},
+						"s": &types.Type{
+							Kind: 7,
+						},
+						"substr": &types.Type{
+							Kind: 7,
+						},
+					},
+				},
+				"8": &CompiledFunc{
+					Arguments: []string{"a", "b"},
+					Instructions: []Instruction{
+						&LessThanNumber{"a", "b", "3"},
+						&JumpUnless{"3", 2},
+						&Return{Registers{"a"}},
+						&Return{Registers{"b"}},
+					},
+					Registers: 3,
+					Variables: map[string]*types.Type{
+						"a": &types.Type{
+							Kind: 6,
+						},
+						"b": &types.Type{
+							Kind: 6,
+						},
+					},
+				},
+				"9": &CompiledFunc{
+					Arguments: []string{"a", "b"},
+					Instructions: []Instruction{
+						&GreaterThanNumber{"a", "b", "3"},
+						&JumpUnless{"3", 2},
+						&Return{Registers{"a"}},
+						&Return{Registers{"b"}},
+					},
+					Registers: 3,
+					Variables: map[string]*types.Type{
+						"a": &types.Type{
+							Kind: 6,
+						},
+						"b": &types.Type{
+							Kind: 6,
+						},
+					},
+				},
 				"Contains": &CompiledFunc{
 					Arguments: []string{"s", "substr"},
 					Instructions: []Instruction{
@@ -929,7 +5054,7 @@ func init() {
 									Kind: 6,
 								},
 							},
-						}, "Index", nil, nil, ""}, ""},
+						}, "6", nil, nil, ""}, ""},
 						&Call{"*3", Registers{"s", "substr"}, Registers{"4"}, &types.Type{
 							Kind: 2,
 						}},
@@ -1088,7 +5213,7 @@ func init() {
 									Kind: 6,
 								},
 							},
-						}, "IndexAfter", nil, nil, ""}, ""},
+						}, "7", nil, nil, ""}, ""},
 						&Call{"*4", Registers{"s", "substr", "3"}, Registers{"5"}, &types.Type{
 							Kind: 2,
 						}},
@@ -1125,7 +5250,7 @@ func init() {
 									Kind: 6,
 								},
 							},
-						}, "max", nil, nil, ""}, ""},
+						}, "9", nil, nil, ""}, ""},
 						&Call{"*5", Registers{"offset", "4"}, Registers{"6"}, &types.Type{
 							Kind: 2,
 						}},
@@ -1259,7 +5384,7 @@ func init() {
 									Kind: 7,
 								},
 							},
-						}, "Reverse", nil, nil, ""}, ""},
+						}, "18", nil, nil, ""}, ""},
 						&Call{"*3", Registers{"s"}, Registers{"4"}, &types.Type{
 							Kind: 2,
 						}},
@@ -1275,7 +5400,7 @@ func init() {
 									Kind: 7,
 								},
 							},
-						}, "Reverse", nil, nil, ""}, ""},
+						}, "18", nil, nil, ""}, ""},
 						&Call{"*5", Registers{"substr"}, Registers{"6"}, &types.Type{
 							Kind: 2,
 						}},
@@ -1294,7 +5419,7 @@ func init() {
 									Kind: 6,
 								},
 							},
-						}, "Index", nil, nil, ""}, ""},
+						}, "6", nil, nil, ""}, ""},
 						&Call{"*7", Registers{"4", "6"}, Registers{"8"}, &types.Type{
 							Kind: 2,
 						}},
@@ -1347,7 +5472,7 @@ func init() {
 									Kind: 6,
 								},
 							},
-						}, "min", nil, nil, ""}, ""},
+						}, "8", nil, nil, ""}, ""},
 						&Call{"*6", Registers{"offset", "5"}, Registers{"7"}, &types.Type{
 							Kind: 2,
 						}},
@@ -1369,7 +5494,7 @@ func init() {
 									Kind: 7,
 								},
 							},
-						}, "Reverse", nil, nil, ""}, ""},
+						}, "18", nil, nil, ""}, ""},
 						&Call{"*11", Registers{"s"}, Registers{"12"}, &types.Type{
 							Kind: 2,
 						}},
@@ -1385,7 +5510,7 @@ func init() {
 									Kind: 7,
 								},
 							},
-						}, "Reverse", nil, nil, ""}, ""},
+						}, "18", nil, nil, ""}, ""},
 						&Call{"*13", Registers{"substr"}, Registers{"14"}, &types.Type{
 							Kind: 2,
 						}},
@@ -1407,7 +5532,7 @@ func init() {
 									Kind: 6,
 								},
 							},
-						}, "IndexAfter", nil, nil, ""}, ""},
+						}, "7", nil, nil, ""}, ""},
 						&Call{"*15", Registers{"12", "14", "offset"}, Registers{"16"}, &types.Type{
 							Kind: 2,
 						}},
@@ -1472,7 +5597,7 @@ func init() {
 									Kind: 7,
 								},
 							},
-						}, "createPad", nil, nil, ""}, ""},
+						}, "15", nil, nil, ""}, ""},
 						&Call{"*11", Registers{"pad", "10"}, Registers{"12"}, &types.Type{
 							Kind: 2,
 						}},
@@ -1521,7 +5646,7 @@ func init() {
 									Kind: 7,
 								},
 							},
-						}, "createPad", nil, nil, ""}, ""},
+						}, "15", nil, nil, ""}, ""},
 						&Call{"*11", Registers{"pad", "10"}, Registers{"12"}, &types.Type{
 							Kind: 2,
 						}},
@@ -1599,7 +5724,7 @@ func init() {
 									},
 								},
 							},
-						}, "Split", nil, nil, ""}, ""},
+						}, "19", nil, nil, ""}, ""},
 						&Call{"*4", Registers{"s", "find"}, Registers{"5"}, &types.Type{
 							Kind: 2,
 						}},
@@ -1621,7 +5746,7 @@ func init() {
 									Kind: 7,
 								},
 							},
-						}, "Join", nil, nil, ""}, ""},
+						}, "12", nil, nil, ""}, ""},
 						&Call{"*6", Registers{"5", "replace"}, Registers{"7"}, &types.Type{
 							Kind: 2,
 						}},
@@ -1761,7 +5886,7 @@ func init() {
 									Kind: 6,
 								},
 							},
-						}, "IndexAfter", nil, nil, ""}, ""},
+						}, "7", nil, nil, ""}, ""},
 						&Call{"*22", Registers{"s", "delimiter", "21"}, Registers{"23"}, &types.Type{
 							Kind: 2,
 						}},
@@ -2009,7 +6134,7 @@ func init() {
 									Kind: 7,
 								},
 							},
-						}, "TrimLeft", nil, nil, ""}, ""},
+						}, "21", nil, nil, ""}, ""},
 						&Call{"*3", Registers{"s", "cutset"}, Registers{"4"}, &types.Type{
 							Kind: 2,
 						}},
@@ -2028,7 +6153,7 @@ func init() {
 									Kind: 7,
 								},
 							},
-						}, "TrimRight", nil, nil, ""}, ""},
+						}, "22", nil, nil, ""}, ""},
 						&Call{"*5", Registers{"4", "cutset"}, Registers{"6"}, &types.Type{
 							Kind: 2,
 						}},
@@ -2071,7 +6196,7 @@ func init() {
 									Kind: 6,
 								},
 							},
-						}, "Index", nil, nil, ""}, ""},
+						}, "6", nil, nil, ""}, ""},
 						&Call{"*8", Registers{"cutset", "7"}, Registers{"9"}, &types.Type{
 							Kind: 2,
 						}},
@@ -2095,7 +6220,7 @@ func init() {
 									Kind: 7,
 								},
 							},
-						}, "substrFrom", nil, nil, ""}, ""},
+						}, "26", nil, nil, ""}, ""},
 						&Call{"*12", Registers{"s", "offset"}, Registers{"13"}, &types.Type{
 							Kind: 2,
 						}},
@@ -2138,7 +6263,7 @@ func init() {
 									Kind: 3,
 								},
 							},
-						}, "HasPrefix", nil, nil, ""}, ""},
+						}, "4", nil, nil, ""}, ""},
 						&Call{"*3", Registers{"s", "prefix"}, Registers{"4"}, &types.Type{
 							Kind: 2,
 						}},
@@ -2159,7 +6284,7 @@ func init() {
 									Kind: 7,
 								},
 							},
-						}, "substrFrom", nil, nil, ""}, ""},
+						}, "26", nil, nil, ""}, ""},
 						&Call{"*6", Registers{"s", "5"}, Registers{"7"}, &types.Type{
 							Kind: 2,
 						}},
@@ -2191,7 +6316,7 @@ func init() {
 									Kind: 7,
 								},
 							},
-						}, "Reverse", nil, nil, ""}, ""},
+						}, "18", nil, nil, ""}, ""},
 						&Call{"*3", Registers{"s"}, Registers{"4"}, &types.Type{
 							Kind: 2,
 						}},
@@ -2210,7 +6335,7 @@ func init() {
 									Kind: 7,
 								},
 							},
-						}, "TrimLeft", nil, nil, ""}, ""},
+						}, "21", nil, nil, ""}, ""},
 						&Call{"*5", Registers{"4", "cutset"}, Registers{"6"}, &types.Type{
 							Kind: 2,
 						}},
@@ -2226,7 +6351,7 @@ func init() {
 									Kind: 7,
 								},
 							},
-						}, "Reverse", nil, nil, ""}, ""},
+						}, "18", nil, nil, ""}, ""},
 						&Call{"*7", Registers{"6"}, Registers{"8"}, &types.Type{
 							Kind: 2,
 						}},
@@ -2257,7 +6382,7 @@ func init() {
 									Kind: 7,
 								},
 							},
-						}, "Reverse", nil, nil, ""}, ""},
+						}, "18", nil, nil, ""}, ""},
 						&Call{"*3", Registers{"s"}, Registers{"4"}, &types.Type{
 							Kind: 2,
 						}},
@@ -2273,7 +6398,7 @@ func init() {
 									Kind: 7,
 								},
 							},
-						}, "Reverse", nil, nil, ""}, ""},
+						}, "18", nil, nil, ""}, ""},
 						&Call{"*5", Registers{"suffix"}, Registers{"6"}, &types.Type{
 							Kind: 2,
 						}},
@@ -2292,7 +6417,7 @@ func init() {
 									Kind: 7,
 								},
 							},
-						}, "TrimPrefix", nil, nil, ""}, ""},
+						}, "24", nil, nil, ""}, ""},
 						&Call{"*7", Registers{"4", "6"}, Registers{"8"}, &types.Type{
 							Kind: 2,
 						}},
@@ -2308,7 +6433,7 @@ func init() {
 									Kind: 7,
 								},
 							},
-						}, "Reverse", nil, nil, ""}, ""},
+						}, "18", nil, nil, ""}, ""},
 						&Call{"*9", Registers{"8"}, Registers{"10"}, &types.Type{
 							Kind: 2,
 						}},
@@ -2344,7 +6469,7 @@ func init() {
 									Kind: 7,
 								},
 							},
-						}, "Repeat", nil, nil, ""}, ""},
+						}, "16", nil, nil, ""}, ""},
 						&Call{"*5", Registers{"pad", "4"}, Registers{"6"}, &types.Type{
 							Kind: 2,
 						}},
@@ -2369,7 +6494,7 @@ func init() {
 									Kind: 7,
 								},
 							},
-						}, "Substr", nil, nil, ""}, ""},
+						}, "20", nil, nil, ""}, ""},
 						&Call{"*8", Registers{"6", "7", "toLen"}, Registers{"9"}, &types.Type{
 							Kind: 2,
 						}},
@@ -2456,8 +6581,492 @@ func init() {
 				},
 			},
 			FuncDefs: map[string]*ast.Func{
+				"1": &ast.Func{
+					Name:       "ToLower",
+					UniqueName: "1",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"s", &types.Type{
+							Kind: 7,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 7,
+						},
+					},
+					Pos: "lib/strings/case.ok:4:1",
+				},
+				"10": &ast.Func{
+					Name:       "LastIndex",
+					UniqueName: "10",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"s", &types.Type{
+							Kind: 7,
+						}},
+						&ast.Argument{"substr", &types.Type{
+							Kind: 7,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 6,
+						},
+					},
+					Pos: "lib/strings/index.ok:57:1",
+				},
+				"11": &ast.Func{
+					Name:       "LastIndexBefore",
+					UniqueName: "11",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"s", &types.Type{
+							Kind: 7,
+						}},
+						&ast.Argument{"substr", &types.Type{
+							Kind: 7,
+						}},
+						&ast.Argument{"offset", &types.Type{
+							Kind: 6,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 6,
+						},
+					},
+					Pos: "lib/strings/index.ok:76:1",
+				},
+				"12": &ast.Func{
+					Name:       "Join",
+					UniqueName: "12",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"strings", &types.Type{
+							Kind: 8,
+							Element: &types.Type{
+								Kind: 7,
+							},
+						}},
+						&ast.Argument{"glue", &types.Type{
+							Kind: 7,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 7,
+						},
+					},
+					Pos: "lib/strings/join.ok:4:1",
+				},
+				"13": &ast.Func{
+					Name:       "PadLeft",
+					UniqueName: "13",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"s", &types.Type{
+							Kind: 7,
+						}},
+						&ast.Argument{"pad", &types.Type{
+							Kind: 7,
+						}},
+						&ast.Argument{"toLen", &types.Type{
+							Kind: 6,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 7,
+						},
+					},
+					Pos: "lib/strings/pad.ok:9:1",
+				},
+				"14": &ast.Func{
+					Name:       "PadRight",
+					UniqueName: "14",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"s", &types.Type{
+							Kind: 7,
+						}},
+						&ast.Argument{"pad", &types.Type{
+							Kind: 7,
+						}},
+						&ast.Argument{"toLen", &types.Type{
+							Kind: 6,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 7,
+						},
+					},
+					Pos: "lib/strings/pad.ok:19:1",
+				},
+				"15": &ast.Func{
+					Name:       "createPad",
+					UniqueName: "15",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"pad", &types.Type{
+							Kind: 7,
+						}},
+						&ast.Argument{"toLen", &types.Type{
+							Kind: 6,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 7,
+						},
+					},
+					Pos: "lib/strings/pad.ok:27:1",
+				},
+				"16": &ast.Func{
+					Name:       "Repeat",
+					UniqueName: "16",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"str", &types.Type{
+							Kind: 7,
+						}},
+						&ast.Argument{"times", &types.Type{
+							Kind: 6,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 7,
+						},
+					},
+					Pos: "lib/strings/repeat.ok:3:1",
+				},
+				"17": &ast.Func{
+					Name:       "ReplaceAll",
+					UniqueName: "17",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"s", &types.Type{
+							Kind: 7,
+						}},
+						&ast.Argument{"find", &types.Type{
+							Kind: 7,
+						}},
+						&ast.Argument{"replace", &types.Type{
+							Kind: 7,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 7,
+						},
+					},
+					Pos: "lib/strings/replace.ok:5:1",
+				},
+				"18": &ast.Func{
+					Name:       "Reverse",
+					UniqueName: "18",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"s", &types.Type{
+							Kind: 7,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 7,
+						},
+					},
+					Pos: "lib/strings/reverse.ok:2:1",
+				},
+				"19": &ast.Func{
+					Name:       "Split",
+					UniqueName: "19",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"s", &types.Type{
+							Kind: 7,
+						}},
+						&ast.Argument{"delimiter", &types.Type{
+							Kind: 7,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 8,
+							Element: &types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					Pos: "lib/strings/split.ok:7:1",
+				},
+				"2": &ast.Func{
+					Name:       "ToUpper",
+					UniqueName: "2",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"s", &types.Type{
+							Kind: 7,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 7,
+						},
+					},
+					Pos: "lib/strings/case.ok:21:1",
+				},
+				"20": &ast.Func{
+					Name:       "Substr",
+					UniqueName: "20",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"s", &types.Type{
+							Kind: 7,
+						}},
+						&ast.Argument{"fromIndex", &types.Type{
+							Kind: 6,
+						}},
+						&ast.Argument{"toIndex", &types.Type{
+							Kind: 6,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 7,
+						},
+					},
+					Pos: "lib/strings/substr.ok:3:1",
+				},
+				"21": &ast.Func{
+					Name:       "TrimLeft",
+					UniqueName: "21",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"s", &types.Type{
+							Kind: 7,
+						}},
+						&ast.Argument{"cutset", &types.Type{
+							Kind: 7,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 7,
+						},
+					},
+					Pos: "lib/strings/trim.ok:3:1",
+				},
+				"22": &ast.Func{
+					Name:       "TrimRight",
+					UniqueName: "22",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"s", &types.Type{
+							Kind: 7,
+						}},
+						&ast.Argument{"cutset", &types.Type{
+							Kind: 7,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 7,
+						},
+					},
+					Pos: "lib/strings/trim.ok:15:1",
+				},
+				"23": &ast.Func{
+					Name:       "Trim",
+					UniqueName: "23",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"s", &types.Type{
+							Kind: 7,
+						}},
+						&ast.Argument{"cutset", &types.Type{
+							Kind: 7,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 7,
+						},
+					},
+					Pos: "lib/strings/trim.ok:21:1",
+				},
+				"24": &ast.Func{
+					Name:       "TrimPrefix",
+					UniqueName: "24",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"s", &types.Type{
+							Kind: 7,
+						}},
+						&ast.Argument{"prefix", &types.Type{
+							Kind: 7,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 7,
+						},
+					},
+					Pos: "lib/strings/trim.ok:32:1",
+				},
+				"25": &ast.Func{
+					Name:       "TrimSuffix",
+					UniqueName: "25",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"s", &types.Type{
+							Kind: 7,
+						}},
+						&ast.Argument{"suffix", &types.Type{
+							Kind: 7,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 7,
+						},
+					},
+					Pos: "lib/strings/trim.ok:47:1",
+				},
+				"26": &ast.Func{
+					Name:       "substrFrom",
+					UniqueName: "26",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"s", &types.Type{
+							Kind: 7,
+						}},
+						&ast.Argument{"index", &types.Type{
+							Kind: 6,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 7,
+						},
+					},
+					Pos: "lib/strings/trim.ok:52:1",
+				},
+				"3": &ast.Func{
+					Name:       "Contains",
+					UniqueName: "3",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"s", &types.Type{
+							Kind: 7,
+						}},
+						&ast.Argument{"substr", &types.Type{
+							Kind: 7,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 3,
+						},
+					},
+					Pos: "lib/strings/contains.ok:2:1",
+				},
+				"4": &ast.Func{
+					Name:       "HasPrefix",
+					UniqueName: "4",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"s", &types.Type{
+							Kind: 7,
+						}},
+						&ast.Argument{"prefix", &types.Type{
+							Kind: 7,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 3,
+						},
+					},
+					Pos: "lib/strings/contains.ok:7:1",
+				},
+				"5": &ast.Func{
+					Name:       "HasSuffix",
+					UniqueName: "5",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"s", &types.Type{
+							Kind: 7,
+						}},
+						&ast.Argument{"suffix", &types.Type{
+							Kind: 7,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 3,
+						},
+					},
+					Pos: "lib/strings/contains.ok:22:1",
+				},
+				"6": &ast.Func{
+					Name:       "Index",
+					UniqueName: "6",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"s", &types.Type{
+							Kind: 7,
+						}},
+						&ast.Argument{"substr", &types.Type{
+							Kind: 7,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 6,
+						},
+					},
+					Pos: "lib/strings/index.ok:2:1",
+				},
+				"7": &ast.Func{
+					Name:       "IndexAfter",
+					UniqueName: "7",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"s", &types.Type{
+							Kind: 7,
+						}},
+						&ast.Argument{"substr", &types.Type{
+							Kind: 7,
+						}},
+						&ast.Argument{"offset", &types.Type{
+							Kind: 6,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 6,
+						},
+					},
+					Pos: "lib/strings/index.ok:17:1",
+				},
+				"8": &ast.Func{
+					Name:       "min",
+					UniqueName: "8",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"a", &types.Type{
+							Kind: 6,
+						}},
+						&ast.Argument{"b", &types.Type{
+							Kind: 6,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 6,
+						},
+					},
+					Pos: "lib/strings/index.ok:39:1",
+				},
+				"9": &ast.Func{
+					Name:       "max",
+					UniqueName: "9",
+					Arguments: []*ast.Argument{
+						&ast.Argument{"a", &types.Type{
+							Kind: 6,
+						}},
+						&ast.Argument{"b", &types.Type{
+							Kind: 6,
+						}},
+					},
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 6,
+						},
+					},
+					Pos: "lib/strings/index.ok:48:1",
+				},
 				"Contains": &ast.Func{
-					Name: "Contains",
+					Name:       "Contains",
+					UniqueName: "3",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"s", &types.Type{
 							Kind: 7,
@@ -2474,7 +7083,8 @@ func init() {
 					Pos: "lib/strings/contains.ok:2:1",
 				},
 				"HasPrefix": &ast.Func{
-					Name: "HasPrefix",
+					Name:       "HasPrefix",
+					UniqueName: "4",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"s", &types.Type{
 							Kind: 7,
@@ -2491,7 +7101,8 @@ func init() {
 					Pos: "lib/strings/contains.ok:7:1",
 				},
 				"HasSuffix": &ast.Func{
-					Name: "HasSuffix",
+					Name:       "HasSuffix",
+					UniqueName: "5",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"s", &types.Type{
 							Kind: 7,
@@ -2508,7 +7119,8 @@ func init() {
 					Pos: "lib/strings/contains.ok:22:1",
 				},
 				"Index": &ast.Func{
-					Name: "Index",
+					Name:       "Index",
+					UniqueName: "6",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"s", &types.Type{
 							Kind: 7,
@@ -2525,7 +7137,8 @@ func init() {
 					Pos: "lib/strings/index.ok:2:1",
 				},
 				"IndexAfter": &ast.Func{
-					Name: "IndexAfter",
+					Name:       "IndexAfter",
+					UniqueName: "7",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"s", &types.Type{
 							Kind: 7,
@@ -2545,7 +7158,8 @@ func init() {
 					Pos: "lib/strings/index.ok:17:1",
 				},
 				"Join": &ast.Func{
-					Name: "Join",
+					Name:       "Join",
+					UniqueName: "12",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"strings", &types.Type{
 							Kind: 8,
@@ -2565,7 +7179,8 @@ func init() {
 					Pos: "lib/strings/join.ok:4:1",
 				},
 				"LastIndex": &ast.Func{
-					Name: "LastIndex",
+					Name:       "LastIndex",
+					UniqueName: "10",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"s", &types.Type{
 							Kind: 7,
@@ -2582,7 +7197,8 @@ func init() {
 					Pos: "lib/strings/index.ok:57:1",
 				},
 				"LastIndexBefore": &ast.Func{
-					Name: "LastIndexBefore",
+					Name:       "LastIndexBefore",
+					UniqueName: "11",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"s", &types.Type{
 							Kind: 7,
@@ -2602,7 +7218,8 @@ func init() {
 					Pos: "lib/strings/index.ok:76:1",
 				},
 				"PadLeft": &ast.Func{
-					Name: "PadLeft",
+					Name:       "PadLeft",
+					UniqueName: "13",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"s", &types.Type{
 							Kind: 7,
@@ -2622,7 +7239,8 @@ func init() {
 					Pos: "lib/strings/pad.ok:9:1",
 				},
 				"PadRight": &ast.Func{
-					Name: "PadRight",
+					Name:       "PadRight",
+					UniqueName: "14",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"s", &types.Type{
 							Kind: 7,
@@ -2642,7 +7260,8 @@ func init() {
 					Pos: "lib/strings/pad.ok:19:1",
 				},
 				"Repeat": &ast.Func{
-					Name: "Repeat",
+					Name:       "Repeat",
+					UniqueName: "16",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"str", &types.Type{
 							Kind: 7,
@@ -2659,7 +7278,8 @@ func init() {
 					Pos: "lib/strings/repeat.ok:3:1",
 				},
 				"ReplaceAll": &ast.Func{
-					Name: "ReplaceAll",
+					Name:       "ReplaceAll",
+					UniqueName: "17",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"s", &types.Type{
 							Kind: 7,
@@ -2679,7 +7299,8 @@ func init() {
 					Pos: "lib/strings/replace.ok:5:1",
 				},
 				"Reverse": &ast.Func{
-					Name: "Reverse",
+					Name:       "Reverse",
+					UniqueName: "18",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"s", &types.Type{
 							Kind: 7,
@@ -2693,7 +7314,8 @@ func init() {
 					Pos: "lib/strings/reverse.ok:2:1",
 				},
 				"Split": &ast.Func{
-					Name: "Split",
+					Name:       "Split",
+					UniqueName: "19",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"s", &types.Type{
 							Kind: 7,
@@ -2713,7 +7335,8 @@ func init() {
 					Pos: "lib/strings/split.ok:7:1",
 				},
 				"Substr": &ast.Func{
-					Name: "Substr",
+					Name:       "Substr",
+					UniqueName: "20",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"s", &types.Type{
 							Kind: 7,
@@ -2733,7 +7356,8 @@ func init() {
 					Pos: "lib/strings/substr.ok:3:1",
 				},
 				"ToLower": &ast.Func{
-					Name: "ToLower",
+					Name:       "ToLower",
+					UniqueName: "1",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"s", &types.Type{
 							Kind: 7,
@@ -2747,7 +7371,8 @@ func init() {
 					Pos: "lib/strings/case.ok:4:1",
 				},
 				"ToUpper": &ast.Func{
-					Name: "ToUpper",
+					Name:       "ToUpper",
+					UniqueName: "2",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"s", &types.Type{
 							Kind: 7,
@@ -2761,7 +7386,8 @@ func init() {
 					Pos: "lib/strings/case.ok:21:1",
 				},
 				"Trim": &ast.Func{
-					Name: "Trim",
+					Name:       "Trim",
+					UniqueName: "23",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"s", &types.Type{
 							Kind: 7,
@@ -2778,7 +7404,8 @@ func init() {
 					Pos: "lib/strings/trim.ok:21:1",
 				},
 				"TrimLeft": &ast.Func{
-					Name: "TrimLeft",
+					Name:       "TrimLeft",
+					UniqueName: "21",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"s", &types.Type{
 							Kind: 7,
@@ -2795,7 +7422,8 @@ func init() {
 					Pos: "lib/strings/trim.ok:3:1",
 				},
 				"TrimPrefix": &ast.Func{
-					Name: "TrimPrefix",
+					Name:       "TrimPrefix",
+					UniqueName: "24",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"s", &types.Type{
 							Kind: 7,
@@ -2812,7 +7440,8 @@ func init() {
 					Pos: "lib/strings/trim.ok:32:1",
 				},
 				"TrimRight": &ast.Func{
-					Name: "TrimRight",
+					Name:       "TrimRight",
+					UniqueName: "22",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"s", &types.Type{
 							Kind: 7,
@@ -2829,7 +7458,8 @@ func init() {
 					Pos: "lib/strings/trim.ok:15:1",
 				},
 				"TrimSuffix": &ast.Func{
-					Name: "TrimSuffix",
+					Name:       "TrimSuffix",
+					UniqueName: "25",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"s", &types.Type{
 							Kind: 7,
@@ -2846,7 +7476,8 @@ func init() {
 					Pos: "lib/strings/trim.ok:47:1",
 				},
 				"createPad": &ast.Func{
-					Name: "createPad",
+					Name:       "createPad",
+					UniqueName: "15",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"pad", &types.Type{
 							Kind: 7,
@@ -2863,7 +7494,8 @@ func init() {
 					Pos: "lib/strings/pad.ok:27:1",
 				},
 				"max": &ast.Func{
-					Name: "max",
+					Name:       "max",
+					UniqueName: "9",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"a", &types.Type{
 							Kind: 6,
@@ -2880,7 +7512,8 @@ func init() {
 					Pos: "lib/strings/index.ok:48:1",
 				},
 				"min": &ast.Func{
-					Name: "min",
+					Name:       "min",
+					UniqueName: "8",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"a", &types.Type{
 							Kind: 6,
@@ -2897,7 +7530,8 @@ func init() {
 					Pos: "lib/strings/index.ok:39:1",
 				},
 				"substrFrom": &ast.Func{
-					Name: "substrFrom",
+					Name:       "substrFrom",
+					UniqueName: "26",
 					Arguments: []*ast.Argument{
 						&ast.Argument{"s", &types.Type{
 							Kind: 7,
@@ -2915,6 +7549,2220 @@ func init() {
 				},
 			},
 			Constants: nil,
+			PackageFunc: &CompiledFunc{
+				Instructions: []Instruction{
+					&Assign{"1", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "1", nil, nil, ""}, ""},
+					&ParentScope{"1"},
+					&Assign{"1", nil, "1"},
+					&Assign{"2", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "10", nil, nil, ""}, ""},
+					&ParentScope{"2"},
+					&Assign{"10", nil, "2"},
+					&Assign{"3", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "11", nil, nil, ""}, ""},
+					&ParentScope{"3"},
+					&Assign{"11", nil, "3"},
+					&Assign{"4", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 8,
+								Element: &types.Type{
+									Kind: 7,
+								},
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "12", nil, nil, ""}, ""},
+					&ParentScope{"4"},
+					&Assign{"12", nil, "4"},
+					&Assign{"5", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "13", nil, nil, ""}, ""},
+					&ParentScope{"5"},
+					&Assign{"13", nil, "5"},
+					&Assign{"6", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "14", nil, nil, ""}, ""},
+					&ParentScope{"6"},
+					&Assign{"14", nil, "6"},
+					&Assign{"7", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "15", nil, nil, ""}, ""},
+					&ParentScope{"7"},
+					&Assign{"15", nil, "7"},
+					&Assign{"8", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "16", nil, nil, ""}, ""},
+					&ParentScope{"8"},
+					&Assign{"16", nil, "8"},
+					&Assign{"9", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "17", nil, nil, ""}, ""},
+					&ParentScope{"9"},
+					&Assign{"17", nil, "9"},
+					&Assign{"10", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "18", nil, nil, ""}, ""},
+					&ParentScope{"10"},
+					&Assign{"18", nil, "10"},
+					&Assign{"11", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 8,
+								Element: &types.Type{
+									Kind: 7,
+								},
+							},
+						},
+					}, "19", nil, nil, ""}, ""},
+					&ParentScope{"11"},
+					&Assign{"19", nil, "11"},
+					&Assign{"12", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "2", nil, nil, ""}, ""},
+					&ParentScope{"12"},
+					&Assign{"2", nil, "12"},
+					&Assign{"13", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "20", nil, nil, ""}, ""},
+					&ParentScope{"13"},
+					&Assign{"20", nil, "13"},
+					&Assign{"14", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "21", nil, nil, ""}, ""},
+					&ParentScope{"14"},
+					&Assign{"21", nil, "14"},
+					&Assign{"15", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "22", nil, nil, ""}, ""},
+					&ParentScope{"15"},
+					&Assign{"22", nil, "15"},
+					&Assign{"16", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "23", nil, nil, ""}, ""},
+					&ParentScope{"16"},
+					&Assign{"23", nil, "16"},
+					&Assign{"17", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "24", nil, nil, ""}, ""},
+					&ParentScope{"17"},
+					&Assign{"24", nil, "17"},
+					&Assign{"18", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "25", nil, nil, ""}, ""},
+					&ParentScope{"18"},
+					&Assign{"25", nil, "18"},
+					&Assign{"19", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "26", nil, nil, ""}, ""},
+					&ParentScope{"19"},
+					&Assign{"26", nil, "19"},
+					&Assign{"20", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 3,
+							},
+						},
+					}, "3", nil, nil, ""}, ""},
+					&ParentScope{"20"},
+					&Assign{"3", nil, "20"},
+					&Assign{"21", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 3,
+							},
+						},
+					}, "4", nil, nil, ""}, ""},
+					&ParentScope{"21"},
+					&Assign{"4", nil, "21"},
+					&Assign{"22", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 3,
+							},
+						},
+					}, "5", nil, nil, ""}, ""},
+					&ParentScope{"22"},
+					&Assign{"5", nil, "22"},
+					&Assign{"23", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "6", nil, nil, ""}, ""},
+					&ParentScope{"23"},
+					&Assign{"6", nil, "23"},
+					&Assign{"24", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "7", nil, nil, ""}, ""},
+					&ParentScope{"24"},
+					&Assign{"7", nil, "24"},
+					&Assign{"25", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "8", nil, nil, ""}, ""},
+					&ParentScope{"25"},
+					&Assign{"8", nil, "25"},
+					&Assign{"26", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "9", nil, nil, ""}, ""},
+					&ParentScope{"26"},
+					&Assign{"9", nil, "26"},
+					&Assign{"27", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 3,
+							},
+						},
+					}, "3", nil, nil, ""}, ""},
+					&ParentScope{"27"},
+					&Assign{"Contains", nil, "27"},
+					&Assign{"28", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 3,
+							},
+						},
+					}, "4", nil, nil, ""}, ""},
+					&ParentScope{"28"},
+					&Assign{"HasPrefix", nil, "28"},
+					&Assign{"29", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 3,
+							},
+						},
+					}, "5", nil, nil, ""}, ""},
+					&ParentScope{"29"},
+					&Assign{"HasSuffix", nil, "29"},
+					&Assign{"30", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "6", nil, nil, ""}, ""},
+					&ParentScope{"30"},
+					&Assign{"Index", nil, "30"},
+					&Assign{"31", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "7", nil, nil, ""}, ""},
+					&ParentScope{"31"},
+					&Assign{"IndexAfter", nil, "31"},
+					&Assign{"32", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 8,
+								Element: &types.Type{
+									Kind: 7,
+								},
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "12", nil, nil, ""}, ""},
+					&ParentScope{"32"},
+					&Assign{"Join", nil, "32"},
+					&Assign{"33", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "10", nil, nil, ""}, ""},
+					&ParentScope{"33"},
+					&Assign{"LastIndex", nil, "33"},
+					&Assign{"34", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "11", nil, nil, ""}, ""},
+					&ParentScope{"34"},
+					&Assign{"LastIndexBefore", nil, "34"},
+					&Assign{"35", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "13", nil, nil, ""}, ""},
+					&ParentScope{"35"},
+					&Assign{"PadLeft", nil, "35"},
+					&Assign{"36", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "14", nil, nil, ""}, ""},
+					&ParentScope{"36"},
+					&Assign{"PadRight", nil, "36"},
+					&Assign{"37", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "16", nil, nil, ""}, ""},
+					&ParentScope{"37"},
+					&Assign{"Repeat", nil, "37"},
+					&Assign{"38", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "17", nil, nil, ""}, ""},
+					&ParentScope{"38"},
+					&Assign{"ReplaceAll", nil, "38"},
+					&Assign{"39", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "18", nil, nil, ""}, ""},
+					&ParentScope{"39"},
+					&Assign{"Reverse", nil, "39"},
+					&Assign{"40", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 8,
+								Element: &types.Type{
+									Kind: 7,
+								},
+							},
+						},
+					}, "19", nil, nil, ""}, ""},
+					&ParentScope{"40"},
+					&Assign{"Split", nil, "40"},
+					&Assign{"41", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "20", nil, nil, ""}, ""},
+					&ParentScope{"41"},
+					&Assign{"Substr", nil, "41"},
+					&Assign{"42", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "1", nil, nil, ""}, ""},
+					&ParentScope{"42"},
+					&Assign{"ToLower", nil, "42"},
+					&Assign{"43", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "2", nil, nil, ""}, ""},
+					&ParentScope{"43"},
+					&Assign{"ToUpper", nil, "43"},
+					&Assign{"44", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "23", nil, nil, ""}, ""},
+					&ParentScope{"44"},
+					&Assign{"Trim", nil, "44"},
+					&Assign{"45", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "21", nil, nil, ""}, ""},
+					&ParentScope{"45"},
+					&Assign{"TrimLeft", nil, "45"},
+					&Assign{"46", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "24", nil, nil, ""}, ""},
+					&ParentScope{"46"},
+					&Assign{"TrimPrefix", nil, "46"},
+					&Assign{"47", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "22", nil, nil, ""}, ""},
+					&ParentScope{"47"},
+					&Assign{"TrimRight", nil, "47"},
+					&Assign{"48", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "25", nil, nil, ""}, ""},
+					&ParentScope{"48"},
+					&Assign{"TrimSuffix", nil, "48"},
+					&Assign{"49", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "15", nil, nil, ""}, ""},
+					&ParentScope{"49"},
+					&Assign{"createPad", nil, "49"},
+					&Assign{"50", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "9", nil, nil, ""}, ""},
+					&ParentScope{"50"},
+					&Assign{"max", nil, "50"},
+					&Assign{"51", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "8", nil, nil, ""}, ""},
+					&ParentScope{"51"},
+					&Assign{"min", nil, "51"},
+					&Assign{"52", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					}, "26", nil, nil, ""}, ""},
+					&ParentScope{"52"},
+					&Assign{"substrFrom", nil, "52"},
+					&Return{Registers{"0"}},
+				},
+				Registers: 52,
+				Variables: map[string]*types.Type{
+					"1": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"10": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"11": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"12": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 8,
+								Element: &types.Type{
+									Kind: 7,
+								},
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"13": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"14": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"15": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"16": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"17": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"18": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"19": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 8,
+								Element: &types.Type{
+									Kind: 7,
+								},
+							},
+						},
+					},
+					"2": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"20": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"21": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"22": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"23": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"24": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"25": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"26": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"3": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 3,
+							},
+						},
+					},
+					"4": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 3,
+							},
+						},
+					},
+					"5": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 3,
+							},
+						},
+					},
+					"6": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"7": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"8": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"9": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"Contains": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 3,
+							},
+						},
+					},
+					"HasPrefix": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 3,
+							},
+						},
+					},
+					"HasSuffix": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 3,
+							},
+						},
+					},
+					"Index": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"IndexAfter": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"Join": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 8,
+								Element: &types.Type{
+									Kind: 7,
+								},
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"LastIndex": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"LastIndexBefore": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"PadLeft": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"PadRight": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"Repeat": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"ReplaceAll": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"Reverse": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"Split": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 8,
+								Element: &types.Type{
+									Kind: 7,
+								},
+							},
+						},
+					},
+					"Substr": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"ToLower": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"ToUpper": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"Trim": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"TrimLeft": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"TrimPrefix": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"TrimRight": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"TrimSuffix": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 7,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"createPad": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+					"max": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"min": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					},
+					"substrFrom": &types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 7,
+							},
+						},
+					},
+				},
+				Type: &types.Type{
+					Kind: 10,
+					Returns: []*types.Type{
+						&types.Type{
+							Kind: 1,
+							Name: "..__strings",
+							Properties: map[string]*types.Type{
+								"Contains": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+										&types.Type{
+											Kind: 7,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 3,
+										},
+									},
+								},
+								"HasPrefix": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+										&types.Type{
+											Kind: 7,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 3,
+										},
+									},
+								},
+								"HasSuffix": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+										&types.Type{
+											Kind: 7,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 3,
+										},
+									},
+								},
+								"Index": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+										&types.Type{
+											Kind: 7,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 6,
+										},
+									},
+								},
+								"IndexAfter": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+										&types.Type{
+											Kind: 7,
+										},
+										&types.Type{
+											Kind: 6,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 6,
+										},
+									},
+								},
+								"Join": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 8,
+											Element: &types.Type{
+												Kind: 7,
+											},
+										},
+										&types.Type{
+											Kind: 7,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+									},
+								},
+								"LastIndex": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+										&types.Type{
+											Kind: 7,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 6,
+										},
+									},
+								},
+								"LastIndexBefore": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+										&types.Type{
+											Kind: 7,
+										},
+										&types.Type{
+											Kind: 6,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 6,
+										},
+									},
+								},
+								"PadLeft": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+										&types.Type{
+											Kind: 7,
+										},
+										&types.Type{
+											Kind: 6,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+									},
+								},
+								"PadRight": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+										&types.Type{
+											Kind: 7,
+										},
+										&types.Type{
+											Kind: 6,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+									},
+								},
+								"Repeat": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+										&types.Type{
+											Kind: 6,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+									},
+								},
+								"ReplaceAll": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+										&types.Type{
+											Kind: 7,
+										},
+										&types.Type{
+											Kind: 7,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+									},
+								},
+								"Reverse": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+									},
+								},
+								"Split": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+										&types.Type{
+											Kind: 7,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 8,
+											Element: &types.Type{
+												Kind: 7,
+											},
+										},
+									},
+								},
+								"Substr": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+										&types.Type{
+											Kind: 6,
+										},
+										&types.Type{
+											Kind: 6,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+									},
+								},
+								"ToLower": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+									},
+								},
+								"ToUpper": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+									},
+								},
+								"Trim": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+										&types.Type{
+											Kind: 7,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+									},
+								},
+								"TrimLeft": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+										&types.Type{
+											Kind: 7,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+									},
+								},
+								"TrimPrefix": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+										&types.Type{
+											Kind: 7,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+									},
+								},
+								"TrimRight": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+										&types.Type{
+											Kind: 7,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+									},
+								},
+								"TrimSuffix": &types.Type{
+									Kind: 10,
+									Arguments: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+										&types.Type{
+											Kind: 7,
+										},
+									},
+									Returns: []*types.Type{
+										&types.Type{
+											Kind: 7,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }

--- a/vm/okc.go
+++ b/vm/okc.go
@@ -17,6 +17,8 @@ type File struct {
 	FuncDefs  map[string]*ast.Func
 	Tests     []*CompiledTest
 	Constants map[string]*ast.Literal
+
+	PackageFunc *CompiledFunc
 }
 
 // Store will create or replace the okc file for the provided package name.

--- a/vm/raise.go
+++ b/vm/raise.go
@@ -25,5 +25,5 @@ func (ins *Raise) Execute(_ *int, vm *VM) error {
 
 // String is the human-readable description of the instruction.
 func (ins *Raise) String() string {
-	return fmt.Sprintf("%s = raise %s", ins.Err, ins.Type)
+	return fmt.Sprintf("raise %s (%s)", ins.Err, ins.Type)
 }


### PR DESCRIPTION
Previously, packages were a collection of named function. Anonymous
functions could be within those named function as literals. Now all
functions are literals and the package itself is compiled as an
interface. This makes the VM treat the package import as an instance
rather than the hacky collection of functions it was before.

To minimise the diff it still does a bit of both, but the remaining code
that uses these old structures will be removed in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/ok/84)
<!-- Reviewable:end -->
