### PR TITLE
Added assert(raise) syntax

### DIFF
--- a/ast/assert.go
+++ b/ast/assert.go
@@ -1,6 +1,6 @@
 package ast
 
-// Assert is used in tests.
+// Assert is for the `assert(BinaryExpr)` syntax.
 type Assert struct {
 	Expr *Binary
 	Pos  string
@@ -8,5 +8,17 @@ type Assert struct {
 
 // Position returns the position.
 func (node *Assert) Position() string {
+	return node.Pos
+}
+
+// AssertRaise is for the `assert(Call raise TypeOrValue)` syntax.
+type AssertRaise struct {
+	Call        *Call
+	TypeOrValue Node
+	Pos         string
+}
+
+// Position returns the position.
+func (node *AssertRaise) Position() string {
 	return node.Pos
 }

--- a/ast/asttest/assert.go
+++ b/ast/asttest/assert.go
@@ -29,6 +29,7 @@ func cmpOptions() cmp.Options {
 	return []cmp.Option{
 		cmpopts.IgnoreFields(ast.Array{}, "Pos"),
 		cmpopts.IgnoreFields(ast.Assert{}, "Pos"),
+		cmpopts.IgnoreFields(ast.AssertRaise{}, "Pos"),
 		cmpopts.IgnoreFields(ast.Break{}, "Pos"),
 		cmpopts.IgnoreFields(ast.Call{}, "Pos"),
 		cmpopts.IgnoreFields(ast.Case{}, "Pos"),

--- a/compiler/statement.go
+++ b/compiler/statement.go
@@ -21,6 +21,9 @@ func compileStatement(compiledFunc *vm.CompiledFunc, statement ast.Node, breakIn
 	case *ast.Assert:
 		return compileAssert(compiledFunc, n, file)
 
+	case *ast.AssertRaise:
+		return compileAssertRaise(compiledFunc, n, file)
+
 	case *ast.For:
 		return compileFor(compiledFunc, n, file)
 

--- a/compiler/unary.go
+++ b/compiler/unary.go
@@ -1,6 +1,8 @@
 package compiler
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/types"
@@ -30,6 +32,10 @@ func compileUnary(
 		return returns2, kinds[0], nil
 
 	case "-":
+		if len(returns1) == 0 {
+			fmt.Println(e.Expr, kinds)
+		}
+
 		zeroAt := compiledFunc.NextRegister()
 		compiledFunc.Append(&vm.Assign{
 			VariableName: zeroAt,

--- a/lib/lang/assert-raise.okt
+++ b/lib/lang/assert-raise.okt
@@ -1,0 +1,9 @@
+import "error"
+
+func raiseAnError() {
+    raise error.Error("oh oh")
+}
+
+test "assert raising a type" {
+    assert(raiseAnError() raise error.Error)
+}

--- a/lib/lang/try.okt
+++ b/lib/lang/try.okt
@@ -1,0 +1,12 @@
+import "error"
+
+test "try and catch" {
+    raised = ""
+    try {
+        raise error.Error("uh oh")
+    } on error.Error {
+        raised = err.Error
+    }
+
+    assert(raised == "uh oh")
+}

--- a/parser/assert.go
+++ b/parser/assert.go
@@ -38,3 +38,48 @@ func consumeAssert(parser *Parser, offset int) (*ast.Assert, int, error) {
 
 	return assert, offset, nil
 }
+
+func consumeAssertRaise(parser *Parser, offset int) (*ast.AssertRaise, int, error) {
+	originalOffset := offset
+	var err error
+	var exprLeft, exprRight ast.Node
+
+	offset, err = consume(parser, offset, []string{
+		lexer.TokenAssert, lexer.TokenParenOpen})
+	if err != nil {
+		return nil, originalOffset, err
+	}
+
+	exprLeft, offset, err = consumeExpr(parser, offset, unlimitedTokens)
+	if err != nil {
+		return nil, originalOffset, err
+	}
+
+	offset, err = consume(parser, offset, []string{lexer.TokenRaise})
+	if err != nil {
+		return nil, originalOffset, err
+	}
+
+	exprRight, offset, err = consumeExpr(parser, offset, unlimitedTokens)
+	if err != nil {
+		return nil, originalOffset, err
+	}
+
+	offset, err = consume(parser, offset, []string{lexer.TokenParenClose})
+	if err != nil {
+		return nil, originalOffset, err
+	}
+
+	assert := &ast.AssertRaise{
+		TypeOrValue: exprRight,
+		Pos:         parser.pos(originalOffset),
+	}
+	if call, ok := exprLeft.(*ast.Call); ok {
+		assert.Call = call
+	} else {
+		parser.appendError(assert,
+			"assert raises must provide a function call on the left")
+	}
+
+	return assert, offset, nil
+}

--- a/parser/assert_test.go
+++ b/parser/assert_test.go
@@ -34,6 +34,29 @@ func TestAssert(t *testing.T) {
 				errors.New("a.ok:1:15 only binary expressions are permitted in assertions"),
 			},
 		},
+		"raise-type": {
+			str: "assert(foo() raise Bar)",
+			expected: &ast.AssertRaise{
+				Call: &ast.Call{
+					Expr: &ast.Identifier{Name: "foo"},
+				},
+				TypeOrValue: &ast.Identifier{Name: "Bar"},
+			},
+		},
+		"raise-value": {
+			str: `assert(foo() raise Error("uh oh"))`,
+			expected: &ast.AssertRaise{
+				Call: &ast.Call{
+					Expr: &ast.Identifier{Name: "foo"},
+				},
+				TypeOrValue: &ast.Call{
+					Expr: &ast.Identifier{Name: "Error"},
+					Arguments: []ast.Node{
+						asttest.NewLiteralString("uh oh"),
+					},
+				},
+			},
+		},
 	} {
 		t.Run(testName, func(t *testing.T) {
 			str := fmt.Sprintf("func main() { %s }", test.str)

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -49,6 +49,12 @@ func consumeStatement(parser *Parser, offset int) (_ ast.Node, _ int, hoist bool
 		return assign, offset, hoist, nil
 	}
 
+	var assertRaise *ast.AssertRaise
+	assertRaise, offset, err = consumeAssertRaise(parser, offset)
+	if err == nil {
+		return assertRaise, offset, hoist, nil
+	}
+
 	var assert *ast.Assert
 	assert, offset, err = consumeAssert(parser, offset)
 	if err == nil {

--- a/parser/types.go
+++ b/parser/types.go
@@ -3,43 +3,79 @@ package parser
 import (
 	"fmt"
 
+	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/types"
 )
 
 func (parser *Parser) resolveInterfaces() error {
+	var err error
+
 	for _, fn := range parser.funcs {
 		// Argument types
 		for _, arg := range fn.Arguments {
-			if arg.Type.Kind == types.KindUnresolvedInterface {
-				// We may not know all the interfaces yet, so only replace those
-				// that are known. resolveInterfaces() will be called again
-				// later. If anything is still unresolved, the compile will have
-				// to handle that.
-				if lookupFn, ok := parser.funcs[arg.Type.Name]; ok {
-					ty, err := lookupFn.Interface()
-					if err != nil {
-						return fmt.Errorf("%v %s", fn.Position(), err)
-					}
-
-					arg.Type = types.NewInterface(arg.Type.Name, ty)
-				}
+			arg.Type, err = parser.resolveInterface(fn, arg.Type)
+			if err != nil {
+				return err
 			}
 		}
 
 		// Return types
 		for i, ret := range fn.Returns {
-			if ret.Kind == types.KindUnresolvedInterface {
-				// We may not know all the interfaces yet, so only replace those
-				// that are known. resolveInterfaces() will be called again
-				// later. If anything is still unresolved, the compile will have
-				// to handle that.
-				if lookupFn, ok := parser.funcs[ret.Name]; ok {
-					ty, err := lookupFn.Interface()
-					if err != nil {
-						return fmt.Errorf("%v %s", fn.Position(), err)
-					}
+			fn.Returns[i], err = parser.resolveInterface(fn, ret)
+			if err != nil {
+				return err
+			}
+		}
 
-					fn.Returns[i] = types.NewInterface(ret.Name, ty)
+		err = parser.resolveInterfacesInStatements(fn.Statements)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, fn := range parser.tests {
+		err = parser.resolveInterfacesInStatements(fn.Statements)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (parser *Parser) resolveInterface(node ast.Node, typ *types.Type) (*types.Type, error) {
+	// We may not know all the interfaces yet, so only replace those that are
+	// known. resolveInterfaces() will be called again later. If anything is
+	// still unresolved, the compile will have to handle that.
+	if typ.Kind == types.KindUnresolvedInterface {
+		// TODO(elliot): This is a hack to get around the fact we have no linker
+		//  yet. Remove in the future.
+		if typ.Name == "error.Error" {
+			return types.ErrorInterface, nil
+		}
+
+		if lookupFn, ok := parser.funcs[typ.Name]; ok {
+			ty, err := lookupFn.Interface()
+			if err != nil {
+				return typ, fmt.Errorf("%v %s", node.Position(), err)
+			}
+
+			return types.NewInterface(typ.Name, ty), nil
+		}
+	}
+
+	return typ, nil
+}
+
+func (parser *Parser) resolveInterfacesInStatements(stmts []ast.Node) error {
+	var err error
+
+	for _, stmt := range stmts {
+		if es, ok := stmt.(*ast.ErrorScope); ok {
+			for _, on := range es.On {
+				on.Type, err = parser.resolveInterface(on, on.Type)
+				if err != nil {
+					return err
 				}
 			}
 		}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -399,7 +399,7 @@ func (vm *VM) LoadFile(pkgVariable string, file *File) error {
 		vm.fns[k] = v
 	}
 
-	vm.tests = file.Tests
+	vm.tests = append(vm.tests, file.Tests...)
 
 	for packageName := range file.Imports {
 		err := vm.LoadPackage(path.Base(packageName), packageName)


### PR DESCRIPTION
"assert(<call> raise <type>)" is just syntactic sugar for:

    raised = false
    try {
        raiseAnError()
    } on error.Error {
        raised = true
    }
    assert(raised == true)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/ok/91)
<!-- Reviewable:end -->
