### PR TITLE
Fix package types in arguments

### DIFF
--- a/parser/func_test.go
+++ b/parser/func_test.go
@@ -200,6 +200,17 @@ func TestFunc(t *testing.T) {
 				},
 			},
 		},
+		"package-argument": {
+			str: "func printTime(t time.Time) {}",
+			expected: map[string]*ast.Func{
+				"printTime": {
+					Name: "printTime",
+					Arguments: []*ast.Argument{
+						{Name: "t", Type: types.NewUnresolvedInterface("time.Time")},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(testName, func(t *testing.T) {
 			p := parser.NewParser(0)

--- a/tests/time/main.ok
+++ b/tests/time/main.ok
@@ -1,0 +1,9 @@
+import "time"
+
+func printTime(t time.Time) {
+    print(t)
+}
+
+func main() {
+    printTime(time.Time(2001, time.August, 9, 1, 46, 40.123))
+}

--- a/tests/time/stdout.txt
+++ b/tests/time/stdout.txt
@@ -1,0 +1,1 @@
+{"Day": 9, "Hour": 1, "Minute": 46, "Month": 8, "Second": 40.123, "Year": 2001}


### PR DESCRIPTION
The parser would not allow imported types like "time.Time" in function
arguments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/ok/92)
<!-- Reviewable:end -->
