### PR TITLE
Fix parent scope variables

### DIFF
--- a/ast/asttest/assert.go
+++ b/ast/asttest/assert.go
@@ -28,8 +28,8 @@ func AssertEqual(t *testing.T, fns1, fns2 interface{}) bool {
 func cmpOptions() cmp.Options {
 	return []cmp.Option{
 		cmpopts.IgnoreFields(ast.Array{}, "Pos"),
-		cmpopts.IgnoreFields(ast.Assert{}, "Pos"),
 		cmpopts.IgnoreFields(ast.AssertRaise{}, "Pos"),
+		cmpopts.IgnoreFields(ast.Assert{}, "Pos"),
 		cmpopts.IgnoreFields(ast.Break{}, "Pos"),
 		cmpopts.IgnoreFields(ast.Call{}, "Pos"),
 		cmpopts.IgnoreFields(ast.Case{}, "Pos"),
@@ -43,8 +43,8 @@ func cmpOptions() cmp.Options {
 		cmpopts.IgnoreFields(ast.Group{}, "Pos"),
 		cmpopts.IgnoreFields(ast.Identifier{}, "Pos"),
 		cmpopts.IgnoreFields(ast.If{}, "Pos"),
-		cmpopts.IgnoreFields(ast.In{}, "Pos"),
 		cmpopts.IgnoreFields(ast.Interpolate{}, "Pos"),
+		cmpopts.IgnoreFields(ast.In{}, "Pos"),
 		cmpopts.IgnoreFields(ast.Key{}, "Pos"),
 		cmpopts.IgnoreFields(ast.Literal{}, "Pos"),
 		cmpopts.IgnoreFields(ast.Map{}, "Pos"),

--- a/compiler/array_test.go
+++ b/compiler/array_test.go
@@ -159,7 +159,7 @@ func TestArray(t *testing.T) {
 				Statements: []ast.Node{
 					test.node,
 				},
-			}, &vm.File{})
+			}, &vm.File{}, nil)
 			if test.err != nil {
 				assert.EqualError(t, err, test.err.Error())
 			} else {

--- a/compiler/assert_test.go
+++ b/compiler/assert_test.go
@@ -65,7 +65,7 @@ func TestAssert(t *testing.T) {
 				Statements: []ast.Node{
 					test.node,
 				},
-			}, &vm.File{})
+			}, &vm.File{}, nil)
 			if test.err != nil {
 				assert.EqualError(t, err, test.err.Error())
 			} else {

--- a/compiler/assign_test.go
+++ b/compiler/assign_test.go
@@ -122,7 +122,7 @@ func TestAssign(t *testing.T) {
 	} {
 		t.Run(testName, func(t *testing.T) {
 			compiledFunc, err := compiler.CompileFunc(newFunc(test.nodes...),
-				&vm.File{})
+				&vm.File{}, nil)
 			if test.err != nil {
 				assert.EqualError(t, err, test.err.Error())
 			} else {

--- a/compiler/binary_test.go
+++ b/compiler/binary_test.go
@@ -1124,7 +1124,7 @@ func TestBinary(t *testing.T) {
 	} {
 		t.Run(testName, func(t *testing.T) {
 			compiledFunc, err := compiler.CompileFunc(newFunc(test.nodes...),
-				&vm.File{})
+				&vm.File{}, nil)
 			if test.err != nil {
 				assert.EqualError(t, err, test.err.Error())
 			} else {

--- a/compiler/call_test.go
+++ b/compiler/call_test.go
@@ -146,7 +146,7 @@ func TestCall(t *testing.T) {
 	} {
 		t.Run(testName, func(t *testing.T) {
 			compiledFunc, err := compiler.CompileFunc(newFunc(test.nodes...),
-				&vm.File{})
+				&vm.File{}, nil)
 			if test.err != nil {
 				assert.EqualError(t, err, test.err.Error())
 			} else {

--- a/compiler/compile.go
+++ b/compiler/compile.go
@@ -65,7 +65,7 @@ func Compile(rootPath, pkgPath string, includeTests bool, anonFunctionName int) 
 		}
 	}
 
-	compiledPackageFn, err := CompileFunc(p.Package(packageAlias), file)
+	compiledPackageFn, err := CompileFunc(p.Package(packageAlias), file, nil)
 	if err != nil {
 		return nil, []error{err}
 	}

--- a/compiler/error_scope_test.go
+++ b/compiler/error_scope_test.go
@@ -179,7 +179,7 @@ func TestErrorScope(t *testing.T) {
 	} {
 		t.Run(testName, func(t *testing.T) {
 			compiledFunc, err := compiler.CompileFunc(newFunc(test.nodes...),
-				&vm.File{})
+				&vm.File{}, nil)
 			if test.err != nil {
 				assert.EqualError(t, err, test.err.Error())
 			} else {

--- a/compiler/expr_test.go
+++ b/compiler/expr_test.go
@@ -151,7 +151,7 @@ func TestExpr(t *testing.T) {
 	} {
 		t.Run(testName, func(t *testing.T) {
 			compiledFunc, err := compiler.CompileFunc(newFunc(test.nodes...),
-				&vm.File{})
+				&vm.File{}, nil)
 			if test.err != nil {
 				assert.EqualError(t, err, test.err.Error())
 			} else {

--- a/compiler/file.go
+++ b/compiler/file.go
@@ -27,7 +27,7 @@ func compile(
 	}
 
 	for _, fn := range funcs {
-		compiledFn, err := CompileFunc(fn, file)
+		compiledFn, err := CompileFunc(fn, file, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/compiler/for_test.go
+++ b/compiler/for_test.go
@@ -860,7 +860,7 @@ func TestFor(t *testing.T) {
 	} {
 		t.Run(testName, func(t *testing.T) {
 			compiledFunc, err := compiler.CompileFunc(newFunc(test.nodes...),
-				&vm.File{})
+				&vm.File{}, nil)
 			if test.err != nil {
 				assert.EqualError(t, err, test.err.Error())
 			} else {

--- a/compiler/func_test.go
+++ b/compiler/func_test.go
@@ -1,15 +1,24 @@
 package compiler_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/ast/asttest"
 	"github.com/elliotchance/ok/compiler"
+	"github.com/elliotchance/ok/parser"
+	"github.com/elliotchance/ok/types"
 	"github.com/elliotchance/ok/vm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func parseFunc(s string) *ast.Func {
+	p := parser.NewParser(0)
+	p.ParseString(s, "a.ok")
+	return p.Funcs()["foo"]
+}
 
 func TestFunc(t *testing.T) {
 	for testName, test := range map[string]struct {
@@ -57,10 +66,68 @@ func TestFunc(t *testing.T) {
 				},
 			},
 		},
+		"oos-exists-arg": {
+			fn: parseFunc("func foo(baz number) { func bar() number { return ^baz } }"),
+			expected: []vm.Instruction{
+				&vm.Assign{
+					VariableName: "2",
+					Value: &ast.Literal{
+						Kind:  types.NewFunc(nil, []*types.Type{types.Number}),
+						Value: "2",
+					},
+				},
+				&vm.ParentScope{
+					X: "2",
+				},
+				&vm.Assign{
+					VariableName: "bar",
+					Register:     "2",
+				},
+			},
+		},
+		"oos-exists-var": {
+			fn: parseFunc("func foo() { baz = 0\n func bar() number { return ^baz } }"),
+			expected: []vm.Instruction{
+				&vm.Assign{
+					VariableName: "1",
+					Value: &ast.Literal{
+						Kind:  types.NewFunc(nil, []*types.Type{types.Number}),
+						Value: "2",
+					},
+				},
+				&vm.ParentScope{
+					X: "1",
+				},
+				&vm.Assign{
+					VariableName: "bar",
+					Register:     "1",
+				},
+				&vm.Assign{
+					VariableName: "2",
+					Value: &ast.Literal{
+						Kind:  types.Number,
+						Value: "0",
+						Pos:   "a.ok:1:20",
+					},
+				},
+				&vm.Assign{
+					VariableName: "baz",
+					Register:     "2",
+				},
+			},
+		},
+		"oos-illegal": {
+			fn:  parseFunc("func foo() { return ^bar }"),
+			err: errors.New("bar does not exist in the parent scope"),
+		},
+		"oos-nonexistent": {
+			fn:  parseFunc("func foo() { func bar() number { return ^baz } }"),
+			err: errors.New("baz does not exist in the parent scope"),
+		},
 	} {
 		t.Run(testName, func(t *testing.T) {
 			compiledFunc, err := compiler.CompileFunc(test.fn,
-				&vm.File{})
+				&vm.File{Funcs: map[string]*vm.CompiledFunc{}}, nil)
 			if test.err != nil {
 				assert.EqualError(t, err, test.err.Error())
 			} else {

--- a/compiler/identifier.go
+++ b/compiler/identifier.go
@@ -1,0 +1,92 @@
+package compiler
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/elliotchance/ok/ast"
+	"github.com/elliotchance/ok/types"
+	"github.com/elliotchance/ok/vm"
+)
+
+func compileIdentifier(
+	compiledFunc *vm.CompiledFunc,
+	e *ast.Identifier,
+	file *vm.File,
+) ([]vm.Register, []*types.Type, error) {
+	if e.Name[0] == '^' {
+		if compiledFunc.Parent == nil || compiledFunc.Parent.Variables[e.Name[1:]] == nil {
+			return nil, nil, fmt.Errorf("%s does not exist in the parent scope", e.Name[1:])
+		}
+
+		// TODO(elliot): We must copy this out-of-scope value to a register
+		//  so that it's found correctly in the stack. This doesn't have to
+		//  be for in-scope variables because they are register names
+		//  themselves. However, the tricky part is that we cannot copy to a
+		//  register if the value is intended to be mutated (eg. ++^i) so
+		//  there needs to be a new option passed down the compile functions
+		//  to indicate this. Without this change code like "padZero(^foo)"
+		//  will not work because the scope will be incorrect by the time
+		//  ^foo is accessed.
+		return []vm.Register{vm.Register(e.Name)}, []*types.Type{
+			compiledFunc.Parent.Variables[e.Name[1:]],
+		}, nil
+	}
+
+	if v, ok := compiledFunc.Variables[e.Name]; ok {
+		return []vm.Register{vm.Register(e.Name)}, []*types.Type{v}, nil
+	}
+
+	// It could be an imported package.
+	for packageName := range file.Imports {
+		if e.Name == packageName || strings.HasSuffix(packageName, "/"+e.Name) {
+			imp := file.Imports[packageName]
+			packageRegister := compiledFunc.NextRegister()
+			compiledFunc.Append(&vm.LoadPackage{
+				Result:      packageRegister,
+				PackageName: e.Name,
+			})
+
+			return []vm.Register{packageRegister}, []*types.Type{imp}, nil
+		}
+	}
+
+	// Constants (defined at the package-level) can be referenced from
+	// anywhere. This only covers the case where we are referencing a
+	// constant that belongs to the current package, as external constants
+	// would be resolved through the package import variable.
+	if c, ok := file.Constants[e.Name]; ok {
+		// We copy it locally to make sure it's value isn't changed. The
+		// compiler will prevent a constant from being modified directly.
+		//
+		// TODO(elliot): The compiler needs to raise an error when trying to
+		//  modify a constant.
+		literalRegister := compiledFunc.NextRegister()
+		compiledFunc.Append(&vm.Assign{
+			VariableName: literalRegister,
+			Value: &ast.Literal{
+				Kind:  c.Kind,
+				Value: c.Value,
+			},
+		})
+
+		return []vm.Register{literalRegister}, []*types.Type{c.Kind}, nil
+	}
+
+	// It could also reference a package-level function.
+	if fn := file.FuncByName(e.Name); fn != nil {
+		literalRegister := compiledFunc.NextRegister()
+		compiledFunc.Append(&vm.Assign{
+			VariableName: literalRegister,
+			Value: &ast.Literal{
+				Kind:  fn.Type,
+				Value: fn.UniqueName,
+			},
+		})
+
+		return []vm.Register{literalRegister}, []*types.Type{fn.Type}, nil
+	}
+
+	return nil, nil, fmt.Errorf("%s undefined variable: %s",
+		e.Pos, e.Name)
+}

--- a/compiler/if_test.go
+++ b/compiler/if_test.go
@@ -221,7 +221,7 @@ func TestIf(t *testing.T) {
 	} {
 		t.Run(testName, func(t *testing.T) {
 			compiledFunc, err := compiler.CompileFunc(newFunc(test.nodes...),
-				&vm.File{})
+				&vm.File{}, nil)
 			if test.err != nil {
 				assert.EqualError(t, err, test.err.Error())
 			} else {

--- a/compiler/interpolate_test.go
+++ b/compiler/interpolate_test.go
@@ -65,7 +65,7 @@ func TestInterpolate(t *testing.T) {
 				Statements: []ast.Node{
 					test.node,
 				},
-			}, &vm.File{})
+			}, &vm.File{}, nil)
 			require.NoError(t, err)
 			assert.Equal(t, test.expected, compiledFunc.Instructions)
 		})

--- a/compiler/key_test.go
+++ b/compiler/key_test.go
@@ -272,236 +272,236 @@ func TestKey(t *testing.T) {
 				},
 			},
 		},
-		//"assign-array-number": {
-		//	nodes: []ast.Node{
-		//		&ast.Assign{
-		//			Lefts: []ast.Node{
-		//				&ast.Identifier{Name: "foo"},
-		//			},
-		//			Rights: []ast.Node{
-		//				&ast.Array{
-		//					Elements: []ast.Node{
-		//						asttest.NewLiteralNumber("123"),
-		//						asttest.NewLiteralNumber("456"),
-		//					},
-		//				},
-		//			},
-		//		},
-		//		&ast.Assign{
-		//			Lefts: []ast.Node{
-		//				&ast.Key{
-		//					Expr: &ast.Identifier{Name: "foo"},
-		//					Key:  asttest.NewLiteralNumber("1"),
-		//				},
-		//			},
-		//			Rights: []ast.Node{
-		//				asttest.NewLiteralNumber("2"),
-		//			},
-		//		},
-		//	},
-		//	expected: []vm.Instruction{
-		//		// alloc
-		//		&vm.Assign{
-		//			VariableName: "1",
-		//			Value:        asttest.NewLiteralNumber("2"),
-		//		},
-		//		&vm.ArrayAlloc{
-		//			Size:   "1",
-		//			Result: "2",
-		//			Kind:   types.NumberArray,
-		//		},
-		//
-		//		// set 0
-		//		&vm.Assign{
-		//			VariableName: "3",
-		//			Value:        asttest.NewLiteralNumber("0"),
-		//		},
-		//		&vm.Assign{
-		//			VariableName: "4",
-		//			Value:        asttest.NewLiteralNumber("123"),
-		//		},
-		//		&vm.ArraySet{
-		//			Array: "2",
-		//			Index: "3",
-		//			Value: "4",
-		//		},
-		//
-		//		// set 1
-		//		&vm.Assign{
-		//			VariableName: "5",
-		//			Value:        asttest.NewLiteralNumber("1"),
-		//		},
-		//		&vm.Assign{
-		//			VariableName: "6",
-		//			Value:        asttest.NewLiteralNumber("456"),
-		//		},
-		//		&vm.ArraySet{
-		//			Array: "2",
-		//			Index: "5",
-		//			Value: "6",
-		//		},
-		//
-		//		// assign foo
-		//		&vm.Assign{
-		//			VariableName: "foo",
-		//			Register:     "2",
-		//		},
-		//
-		//		// foo[1] = 2
-		//		&vm.Assign{
-		//			VariableName: "7",
-		//			Value:        asttest.NewLiteralNumber("2"),
-		//		},
-		//		&vm.Assign{
-		//			VariableName: "8",
-		//			Value:        asttest.NewLiteralNumber("1"),
-		//		},
-		//		&vm.ArraySet{
-		//			Array: "foo",
-		//			Index: "8",
-		//			Value: "7",
-		//		},
-		//	},
-		//},
-		//"assign-map-number": {
-		//	nodes: []ast.Node{
-		//		&ast.Assign{
-		//			Lefts: []ast.Node{
-		//				&ast.Identifier{Name: "foo"},
-		//			},
-		//			Rights: []ast.Node{
-		//				&ast.Map{
-		//					Elements: []*ast.KeyValue{
-		//						{
-		//							Key:   asttest.NewLiteralString("a"),
-		//							Value: asttest.NewLiteralNumber("123"),
-		//						},
-		//						{
-		//							Key:   asttest.NewLiteralString("b"),
-		//							Value: asttest.NewLiteralNumber("456"),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		},
-		//		&ast.Assign{
-		//			Lefts: []ast.Node{
-		//				&ast.Key{
-		//					Expr: &ast.Identifier{Name: "foo"},
-		//					Key:  asttest.NewLiteralString("b"),
-		//				},
-		//			},
-		//			Rights: []ast.Node{
-		//				asttest.NewLiteralNumber("2"),
-		//			},
-		//		},
-		//	},
-		//	expected: []vm.Instruction{
-		//		// alloc
-		//		&vm.Assign{
-		//			VariableName: "1",
-		//			Value:        asttest.NewLiteralNumber("2"),
-		//		},
-		//		&vm.MapAlloc{
-		//			Kind:   types.NumberMap,
-		//			Size:   "1",
-		//			Result: "2",
-		//		},
-		//
-		//		// "a": 123
-		//		&vm.Assign{
-		//			VariableName: "3",
-		//			Value:        asttest.NewLiteralString("a"),
-		//		},
-		//		&vm.Assign{
-		//			VariableName: "4",
-		//			Value:        asttest.NewLiteralNumber("123"),
-		//		},
-		//		&vm.MapSet{
-		//			Map:   "2",
-		//			Key:   "3",
-		//			Value: "4",
-		//		},
-		//
-		//		// "b": 456
-		//		&vm.Assign{
-		//			VariableName: "5",
-		//			Value:        asttest.NewLiteralString("b"),
-		//		},
-		//		&vm.Assign{
-		//			VariableName: "6",
-		//			Value:        asttest.NewLiteralNumber("456"),
-		//		},
-		//		&vm.MapSet{
-		//			Map:   "2",
-		//			Key:   "5",
-		//			Value: "6",
-		//		},
-		//
-		//		// assign foo
-		//		&vm.Assign{
-		//			VariableName: "foo",
-		//			Register:     "2",
-		//		},
-		//
-		//		// foo["b"] = 2
-		//		&vm.Assign{
-		//			VariableName: "7",
-		//			Value:        asttest.NewLiteralNumber("2"),
-		//		},
-		//		&vm.Assign{
-		//			VariableName: "8",
-		//			Value:        asttest.NewLiteralString("b"),
-		//		},
-		//		&vm.MapSet{
-		//			Map:   "foo",
-		//			Key:   "8",
-		//			Value: "7",
-		//		},
-		//	},
-		//},
-		//"string-number-index": {
-		//	nodes: []ast.Node{
-		//		&ast.Assign{
-		//			Lefts: []ast.Node{
-		//				&ast.Identifier{Name: "foo"},
-		//			},
-		//			Rights: []ast.Node{
-		//				asttest.NewLiteralString("bar"),
-		//			},
-		//		},
-		//		&ast.Key{
-		//			Expr: &ast.Identifier{Name: "foo"},
-		//			Key:  asttest.NewLiteralNumber("1"),
-		//		},
-		//	},
-		//	expected: []vm.Instruction{
-		//		&vm.Assign{
-		//			VariableName: "1",
-		//			Value:        asttest.NewLiteralString("bar"),
-		//		},
-		//		&vm.Assign{
-		//			VariableName: "foo",
-		//			Register:     "1",
-		//		},
-		//
-		//		// foo[1]
-		//		&vm.Assign{
-		//			VariableName: "2",
-		//			Value:        asttest.NewLiteralNumber("1"),
-		//		},
-		//		&vm.StringIndex{
-		//			Str:    "foo",
-		//			Index:  "2",
-		//			Result: "3",
-		//		},
-		//	},
-		//},
+		"assign-array-number": {
+			nodes: []ast.Node{
+				&ast.Assign{
+					Lefts: []ast.Node{
+						&ast.Identifier{Name: "foo"},
+					},
+					Rights: []ast.Node{
+						&ast.Array{
+							Elements: []ast.Node{
+								asttest.NewLiteralNumber("123"),
+								asttest.NewLiteralNumber("456"),
+							},
+						},
+					},
+				},
+				&ast.Assign{
+					Lefts: []ast.Node{
+						&ast.Key{
+							Expr: &ast.Identifier{Name: "foo"},
+							Key:  asttest.NewLiteralNumber("1"),
+						},
+					},
+					Rights: []ast.Node{
+						asttest.NewLiteralNumber("2"),
+					},
+				},
+			},
+			expected: []vm.Instruction{
+				// alloc
+				&vm.Assign{
+					VariableName: "1",
+					Value:        asttest.NewLiteralNumber("2"),
+				},
+				&vm.ArrayAlloc{
+					Size:   "1",
+					Result: "2",
+					Kind:   types.NumberArray,
+				},
+
+				// set 0
+				&vm.Assign{
+					VariableName: "3",
+					Value:        asttest.NewLiteralNumber("0"),
+				},
+				&vm.Assign{
+					VariableName: "4",
+					Value:        asttest.NewLiteralNumber("123"),
+				},
+				&vm.ArraySet{
+					Array: "2",
+					Index: "3",
+					Value: "4",
+				},
+
+				// set 1
+				&vm.Assign{
+					VariableName: "5",
+					Value:        asttest.NewLiteralNumber("1"),
+				},
+				&vm.Assign{
+					VariableName: "6",
+					Value:        asttest.NewLiteralNumber("456"),
+				},
+				&vm.ArraySet{
+					Array: "2",
+					Index: "5",
+					Value: "6",
+				},
+
+				// assign foo
+				&vm.Assign{
+					VariableName: "foo",
+					Register:     "2",
+				},
+
+				// foo[1] = 2
+				&vm.Assign{
+					VariableName: "7",
+					Value:        asttest.NewLiteralNumber("2"),
+				},
+				&vm.Assign{
+					VariableName: "8",
+					Value:        asttest.NewLiteralNumber("1"),
+				},
+				&vm.ArraySet{
+					Array: "foo",
+					Index: "8",
+					Value: "7",
+				},
+			},
+		},
+		"assign-map-number": {
+			nodes: []ast.Node{
+				&ast.Assign{
+					Lefts: []ast.Node{
+						&ast.Identifier{Name: "foo"},
+					},
+					Rights: []ast.Node{
+						&ast.Map{
+							Elements: []*ast.KeyValue{
+								{
+									Key:   asttest.NewLiteralString("a"),
+									Value: asttest.NewLiteralNumber("123"),
+								},
+								{
+									Key:   asttest.NewLiteralString("b"),
+									Value: asttest.NewLiteralNumber("456"),
+								},
+							},
+						},
+					},
+				},
+				&ast.Assign{
+					Lefts: []ast.Node{
+						&ast.Key{
+							Expr: &ast.Identifier{Name: "foo"},
+							Key:  asttest.NewLiteralString("b"),
+						},
+					},
+					Rights: []ast.Node{
+						asttest.NewLiteralNumber("2"),
+					},
+				},
+			},
+			expected: []vm.Instruction{
+				// alloc
+				&vm.Assign{
+					VariableName: "1",
+					Value:        asttest.NewLiteralNumber("2"),
+				},
+				&vm.MapAlloc{
+					Kind:   types.NumberMap,
+					Size:   "1",
+					Result: "2",
+				},
+
+				// "a": 123
+				&vm.Assign{
+					VariableName: "3",
+					Value:        asttest.NewLiteralString("a"),
+				},
+				&vm.Assign{
+					VariableName: "4",
+					Value:        asttest.NewLiteralNumber("123"),
+				},
+				&vm.MapSet{
+					Map:   "2",
+					Key:   "3",
+					Value: "4",
+				},
+
+				// "b": 456
+				&vm.Assign{
+					VariableName: "5",
+					Value:        asttest.NewLiteralString("b"),
+				},
+				&vm.Assign{
+					VariableName: "6",
+					Value:        asttest.NewLiteralNumber("456"),
+				},
+				&vm.MapSet{
+					Map:   "2",
+					Key:   "5",
+					Value: "6",
+				},
+
+				// assign foo
+				&vm.Assign{
+					VariableName: "foo",
+					Register:     "2",
+				},
+
+				// foo["b"] = 2
+				&vm.Assign{
+					VariableName: "7",
+					Value:        asttest.NewLiteralNumber("2"),
+				},
+				&vm.Assign{
+					VariableName: "8",
+					Value:        asttest.NewLiteralString("b"),
+				},
+				&vm.MapSet{
+					Map:   "foo",
+					Key:   "8",
+					Value: "7",
+				},
+			},
+		},
+		"string-number-index": {
+			nodes: []ast.Node{
+				&ast.Assign{
+					Lefts: []ast.Node{
+						&ast.Identifier{Name: "foo"},
+					},
+					Rights: []ast.Node{
+						asttest.NewLiteralString("bar"),
+					},
+				},
+				&ast.Key{
+					Expr: &ast.Identifier{Name: "foo"},
+					Key:  asttest.NewLiteralNumber("1"),
+				},
+			},
+			expected: []vm.Instruction{
+				&vm.Assign{
+					VariableName: "1",
+					Value:        asttest.NewLiteralString("bar"),
+				},
+				&vm.Assign{
+					VariableName: "foo",
+					Register:     "1",
+				},
+
+				// foo[1]
+				&vm.Assign{
+					VariableName: "2",
+					Value:        asttest.NewLiteralNumber("1"),
+				},
+				&vm.StringIndex{
+					Str:    "foo",
+					Index:  "2",
+					Result: "3",
+				},
+			},
+		},
 	} {
 		t.Run(testName, func(t *testing.T) {
 			compiledFunc, err := compiler.CompileFunc(&ast.Func{
 				Statements: test.nodes,
-			}, &vm.File{})
+			}, &vm.File{}, nil)
 			if test.err != nil {
 				assert.EqualError(t, err, test.err.Error())
 			} else {

--- a/compiler/map_test.go
+++ b/compiler/map_test.go
@@ -166,7 +166,7 @@ func TestMap(t *testing.T) {
 				Statements: []ast.Node{
 					test.node,
 				},
-			}, &vm.File{})
+			}, &vm.File{}, nil)
 			if test.err != nil {
 				assert.EqualError(t, err, test.err.Error())
 			} else {

--- a/compiler/object_test.go
+++ b/compiler/object_test.go
@@ -65,7 +65,7 @@ func TestObject(t *testing.T) {
 	} {
 		t.Run(testName, func(t *testing.T) {
 			compiledFunc, err := compiler.CompileFunc(test.node,
-				&vm.File{})
+				&vm.File{}, nil)
 			if test.err != nil {
 				assert.EqualError(t, err, test.err.Error())
 			} else {

--- a/compiler/return_test.go
+++ b/compiler/return_test.go
@@ -66,7 +66,7 @@ func TestReturn(t *testing.T) {
 				Statements: []ast.Node{
 					test.node,
 				},
-			}, &vm.File{})
+			}, &vm.File{}, nil)
 			if test.err != nil {
 				assert.EqualError(t, err, test.err.Error())
 			} else {

--- a/compiler/switch_test.go
+++ b/compiler/switch_test.go
@@ -583,7 +583,7 @@ func TestSwitch(t *testing.T) {
 	} {
 		t.Run(testName, func(t *testing.T) {
 			compiledFunc, err := compiler.CompileFunc(test.fn,
-				&vm.File{})
+				&vm.File{}, nil)
 			if test.err != nil {
 				assert.EqualError(t, err, test.err.Error())
 			} else {

--- a/compiler/test.go
+++ b/compiler/test.go
@@ -9,10 +9,13 @@ import (
 func CompileTest(fn *ast.Test, file *vm.File) (*vm.CompiledTest, error) {
 	// Tests can be compiled as if they were functions, then wrapped in a
 	// CompiledTest.
+	//
+	// TODO(elliot): When tests can be nested the third argument for parentFunc
+	//  should not be nil.
 	compiledFunc, err := CompileFunc(&ast.Func{
 		Statements: fn.Statements,
 		Pos:        fn.Pos,
-	}, file)
+	}, file, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/compiler/unary_test.go
+++ b/compiler/unary_test.go
@@ -127,7 +127,7 @@ func TestUnary(t *testing.T) {
 	} {
 		t.Run(testName, func(t *testing.T) {
 			compiledFunc, err := compiler.CompileFunc(newFunc(test.nodes...),
-				&vm.File{})
+				&vm.File{}, nil)
 			if test.err != nil {
 				assert.EqualError(t, err, test.err.Error())
 			} else {

--- a/vm/func.go
+++ b/vm/func.go
@@ -3,6 +3,7 @@ package vm
 import (
 	"fmt"
 
+	"github.com/elliotchance/ok/ast"
 	"github.com/elliotchance/ok/types"
 )
 
@@ -17,6 +18,16 @@ type CompiledFunc struct {
 	// Name and Pos are used by the VM for stack traces.
 	Type                  *types.Type
 	Name, UniqueName, Pos string
+
+	// These are only transient for the compiler, they will be nil when
+	// serialized.
+	Parent                 *CompiledFunc
+	DeferredFuncsToCompile []DeferredFunc
+}
+
+type DeferredFunc struct {
+	Register Register
+	Func     *ast.Func
 }
 
 type FinallyBlock struct {

--- a/vm/lib.go
+++ b/vm/lib.go
@@ -66,7 +66,6 @@ func init() {
 						},
 					}, "1", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"1"},
-					&Assign{"1", nil, "1"},
 					&Assign{"2", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -87,6 +86,7 @@ func init() {
 						},
 					}, "1", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"2"},
+					&Assign{"1", nil, "1"},
 					&Assign{"Error", nil, "2"},
 					&Return{Registers{"0"}},
 				},
@@ -636,6 +636,316 @@ func init() {
 			},
 			PackageFunc: &CompiledFunc{
 				Instructions: []Instruction{
+					&Assign{"10", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "1", nil, nil, "", nil, nil}, ""},
+					&ParentScope{"10"},
+					&Assign{"11", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "10", nil, nil, "", nil, nil}, ""},
+					&ParentScope{"11"},
+					&Assign{"12", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "11", nil, nil, "", nil, nil}, ""},
+					&ParentScope{"12"},
+					&Assign{"13", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "2", nil, nil, "", nil, nil}, ""},
+					&ParentScope{"13"},
+					&Assign{"14", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "3", nil, nil, "", nil, nil}, ""},
+					&ParentScope{"14"},
+					&Assign{"15", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "4", nil, nil, "", nil, nil}, ""},
+					&ParentScope{"15"},
+					&Assign{"16", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "5", nil, nil, "", nil, nil}, ""},
+					&ParentScope{"16"},
+					&Assign{"17", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "6", nil, nil, "", nil, nil}, ""},
+					&ParentScope{"17"},
+					&Assign{"18", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "7", nil, nil, "", nil, nil}, ""},
+					&ParentScope{"18"},
+					&Assign{"19", &ast.Literal{&types.Type{
+						Kind: 10,
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "8", nil, nil, "", nil, nil}, ""},
+					&ParentScope{"19"},
+					&Assign{"20", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "9", nil, nil, "", nil, nil}, ""},
+					&ParentScope{"20"},
+					&Assign{"21", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "1", nil, nil, "", nil, nil}, ""},
+					&ParentScope{"21"},
+					&Assign{"22", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "7", nil, nil, "", nil, nil}, ""},
+					&ParentScope{"22"},
+					&Assign{"23", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "9", nil, nil, "", nil, nil}, ""},
+					&ParentScope{"23"},
+					&Assign{"24", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "4", nil, nil, "", nil, nil}, ""},
+					&ParentScope{"24"},
+					&Assign{"25", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "10", nil, nil, "", nil, nil}, ""},
+					&ParentScope{"25"},
+					&Assign{"26", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "3", nil, nil, "", nil, nil}, ""},
+					&ParentScope{"26"},
+					&Assign{"27", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "2", nil, nil, "", nil, nil}, ""},
+					&ParentScope{"27"},
+					&Assign{"28", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "5", nil, nil, "", nil, nil}, ""},
+					&ParentScope{"28"},
+					&Assign{"29", &ast.Literal{&types.Type{
+						Kind: 10,
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "8", nil, nil, "", nil, nil}, ""},
+					&ParentScope{"29"},
+					&Assign{"30", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "11", nil, nil, "", nil, nil}, ""},
+					&ParentScope{"30"},
+					&Assign{"31", &ast.Literal{&types.Type{
+						Kind: 10,
+						Arguments: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+						Returns: []*types.Type{
+							&types.Type{
+								Kind: 6,
+							},
+						},
+					}, "6", nil, nil, "", nil, nil}, ""},
+					&ParentScope{"31"},
 					&Assign{"1", &ast.Literal{&types.Type{
 						Kind: 6,
 					}, "2.71828182845904523536028747135266249775724709369995957496696763", nil, nil, "lib/math/constants.ok:1:7", nil, nil}, ""},
@@ -672,337 +982,27 @@ func init() {
 						Kind: 6,
 					}, "1.77245385090551602729816748334114518279754945612238712821380779", nil, nil, "lib/math/constants.ok:7:11", nil, nil}, ""},
 					&Assign{"SqrtPi", nil, "9"},
-					&Assign{"10", &ast.Literal{&types.Type{
-						Kind: 10,
-						Arguments: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-						Returns: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-					}, "1", nil, nil, "", nil, nil}, ""},
-					&ParentScope{"10"},
 					&Assign{"1", nil, "10"},
-					&Assign{"11", &ast.Literal{&types.Type{
-						Kind: 10,
-						Arguments: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-						Returns: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-					}, "10", nil, nil, "", nil, nil}, ""},
-					&ParentScope{"11"},
 					&Assign{"10", nil, "11"},
-					&Assign{"12", &ast.Literal{&types.Type{
-						Kind: 10,
-						Arguments: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-							&types.Type{
-								Kind: 6,
-							},
-						},
-						Returns: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-					}, "11", nil, nil, "", nil, nil}, ""},
-					&ParentScope{"12"},
 					&Assign{"11", nil, "12"},
-					&Assign{"13", &ast.Literal{&types.Type{
-						Kind: 10,
-						Arguments: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-						Returns: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-					}, "2", nil, nil, "", nil, nil}, ""},
-					&ParentScope{"13"},
 					&Assign{"2", nil, "13"},
-					&Assign{"14", &ast.Literal{&types.Type{
-						Kind: 10,
-						Arguments: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-						Returns: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-					}, "3", nil, nil, "", nil, nil}, ""},
-					&ParentScope{"14"},
 					&Assign{"3", nil, "14"},
-					&Assign{"15", &ast.Literal{&types.Type{
-						Kind: 10,
-						Arguments: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-						Returns: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-					}, "4", nil, nil, "", nil, nil}, ""},
-					&ParentScope{"15"},
 					&Assign{"4", nil, "15"},
-					&Assign{"16", &ast.Literal{&types.Type{
-						Kind: 10,
-						Arguments: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-							&types.Type{
-								Kind: 6,
-							},
-						},
-						Returns: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-					}, "5", nil, nil, "", nil, nil}, ""},
-					&ParentScope{"16"},
 					&Assign{"5", nil, "16"},
-					&Assign{"17", &ast.Literal{&types.Type{
-						Kind: 10,
-						Arguments: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-						Returns: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-					}, "6", nil, nil, "", nil, nil}, ""},
-					&ParentScope{"17"},
 					&Assign{"6", nil, "17"},
-					&Assign{"18", &ast.Literal{&types.Type{
-						Kind: 10,
-						Arguments: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-						Returns: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-					}, "7", nil, nil, "", nil, nil}, ""},
-					&ParentScope{"18"},
 					&Assign{"7", nil, "18"},
-					&Assign{"19", &ast.Literal{&types.Type{
-						Kind: 10,
-						Returns: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-					}, "8", nil, nil, "", nil, nil}, ""},
-					&ParentScope{"19"},
 					&Assign{"8", nil, "19"},
-					&Assign{"20", &ast.Literal{&types.Type{
-						Kind: 10,
-						Arguments: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-						Returns: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-					}, "9", nil, nil, "", nil, nil}, ""},
-					&ParentScope{"20"},
 					&Assign{"9", nil, "20"},
-					&Assign{"21", &ast.Literal{&types.Type{
-						Kind: 10,
-						Arguments: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-						Returns: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-					}, "1", nil, nil, "", nil, nil}, ""},
-					&ParentScope{"21"},
 					&Assign{"Abs", nil, "21"},
-					&Assign{"22", &ast.Literal{&types.Type{
-						Kind: 10,
-						Arguments: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-						Returns: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-					}, "7", nil, nil, "", nil, nil}, ""},
-					&ParentScope{"22"},
 					&Assign{"Cbrt", nil, "22"},
-					&Assign{"23", &ast.Literal{&types.Type{
-						Kind: 10,
-						Arguments: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-						Returns: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-					}, "9", nil, nil, "", nil, nil}, ""},
-					&ParentScope{"23"},
 					&Assign{"Ceil", nil, "23"},
-					&Assign{"24", &ast.Literal{&types.Type{
-						Kind: 10,
-						Arguments: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-						Returns: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-					}, "4", nil, nil, "", nil, nil}, ""},
-					&ParentScope{"24"},
 					&Assign{"Exp", nil, "24"},
-					&Assign{"25", &ast.Literal{&types.Type{
-						Kind: 10,
-						Arguments: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-						Returns: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-					}, "10", nil, nil, "", nil, nil}, ""},
-					&ParentScope{"25"},
 					&Assign{"Floor", nil, "25"},
-					&Assign{"26", &ast.Literal{&types.Type{
-						Kind: 10,
-						Arguments: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-						Returns: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-					}, "3", nil, nil, "", nil, nil}, ""},
-					&ParentScope{"26"},
 					&Assign{"Log10", nil, "26"},
-					&Assign{"27", &ast.Literal{&types.Type{
-						Kind: 10,
-						Arguments: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-						Returns: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-					}, "2", nil, nil, "", nil, nil}, ""},
-					&ParentScope{"27"},
 					&Assign{"LogE", nil, "27"},
-					&Assign{"28", &ast.Literal{&types.Type{
-						Kind: 10,
-						Arguments: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-							&types.Type{
-								Kind: 6,
-							},
-						},
-						Returns: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-					}, "5", nil, nil, "", nil, nil}, ""},
-					&ParentScope{"28"},
 					&Assign{"Pow", nil, "28"},
-					&Assign{"29", &ast.Literal{&types.Type{
-						Kind: 10,
-						Returns: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-					}, "8", nil, nil, "", nil, nil}, ""},
-					&ParentScope{"29"},
 					&Assign{"Rand", nil, "29"},
-					&Assign{"30", &ast.Literal{&types.Type{
-						Kind: 10,
-						Arguments: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-							&types.Type{
-								Kind: 6,
-							},
-						},
-						Returns: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-					}, "11", nil, nil, "", nil, nil}, ""},
-					&ParentScope{"30"},
 					&Assign{"Round", nil, "30"},
-					&Assign{"31", &ast.Literal{&types.Type{
-						Kind: 10,
-						Arguments: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-						Returns: []*types.Type{
-							&types.Type{
-								Kind: 6,
-							},
-						},
-					}, "6", nil, nil, "", nil, nil}, ""},
-					&ParentScope{"31"},
 					&Assign{"Sqrt", nil, "31"},
 					&Return{Registers{"0"}},
 				},
@@ -2391,7 +2391,6 @@ func init() {
 							},
 						}, "8", nil, nil, "", nil, nil}, ""},
 						&ParentScope{"2"},
-						&Assign{"ReadLine", nil, "2"},
 						&Assign{"3", &ast.Literal{&types.Type{
 							Kind: 10,
 							Arguments: []*types.Type{
@@ -2406,7 +2405,6 @@ func init() {
 							},
 						}, "7", nil, nil, "", nil, nil}, ""},
 						&ParentScope{"3"},
-						&Assign{"ReadString", nil, "3"},
 						&Assign{"4", &ast.Literal{&types.Type{
 							Kind: 10,
 							Arguments: []*types.Type{
@@ -2421,7 +2419,6 @@ func init() {
 							},
 						}, "6", nil, nil, "", nil, nil}, ""},
 						&ParentScope{"4"},
-						&Assign{"ReadData", nil, "4"},
 						&Assign{"5", &ast.Literal{&types.Type{
 							Kind: 10,
 							Arguments: []*types.Type{
@@ -2439,12 +2436,10 @@ func init() {
 							},
 						}, "5", nil, nil, "", nil, nil}, ""},
 						&ParentScope{"5"},
-						&Assign{"Seek", nil, "5"},
 						&Assign{"6", &ast.Literal{&types.Type{
 							Kind: 10,
 						}, "4", nil, nil, "", nil, nil}, ""},
 						&ParentScope{"6"},
-						&Assign{"Close", nil, "6"},
 						&Assign{"7", &ast.Literal{&types.Type{
 							Kind: 10,
 							Arguments: []*types.Type{
@@ -2454,7 +2449,6 @@ func init() {
 							},
 						}, "3", nil, nil, "", nil, nil}, ""},
 						&ParentScope{"7"},
-						&Assign{"WriteData", nil, "7"},
 						&Assign{"8", &ast.Literal{&types.Type{
 							Kind: 10,
 							Arguments: []*types.Type{
@@ -2464,6 +2458,12 @@ func init() {
 							},
 						}, "2", nil, nil, "", nil, nil}, ""},
 						&ParentScope{"8"},
+						&Assign{"ReadLine", nil, "2"},
+						&Assign{"ReadString", nil, "3"},
+						&Assign{"ReadData", nil, "4"},
+						&Assign{"Seek", nil, "5"},
+						&Assign{"Close", nil, "6"},
+						&Assign{"WriteData", nil, "7"},
 						&Assign{"WriteString", nil, "8"},
 						&Return{Registers{"0"}},
 					},
@@ -3587,7 +3587,6 @@ func init() {
 						},
 					}, "1", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"1"},
-					&Assign{"1", nil, "1"},
 					&Assign{"2", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -3597,7 +3596,6 @@ func init() {
 						},
 					}, "10", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"2"},
-					&Assign{"10", nil, "2"},
 					&Assign{"3", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -3610,7 +3608,6 @@ func init() {
 						},
 					}, "11", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"3"},
-					&Assign{"11", nil, "3"},
 					&Assign{"4", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -3620,7 +3617,6 @@ func init() {
 						},
 					}, "12", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"4"},
-					&Assign{"12", nil, "4"},
 					&Assign{"5", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -3665,7 +3661,6 @@ func init() {
 						},
 					}, "13", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"5"},
-					&Assign{"13", nil, "5"},
 					&Assign{"6", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -3698,7 +3693,6 @@ func init() {
 						},
 					}, "14", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"6"},
-					&Assign{"14", nil, "6"},
 					&Assign{"7", &ast.Literal{&types.Type{
 						Kind: 10,
 						Returns: []*types.Type{
@@ -3708,7 +3702,6 @@ func init() {
 						},
 					}, "15", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"7"},
-					&Assign{"15", nil, "7"},
 					&Assign{"8", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -3795,7 +3788,6 @@ func init() {
 						},
 					}, "9", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"8"},
-					&Assign{"9", nil, "8"},
 					&Assign{"9", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -3805,7 +3797,6 @@ func init() {
 						},
 					}, "12", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"9"},
-					&Assign{"CreateDirectory", nil, "9"},
 					&Assign{"10", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -3892,7 +3883,6 @@ func init() {
 						},
 					}, "1", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"10"},
-					&Assign{"File", nil, "10"},
 					&Assign{"11", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -3937,7 +3927,6 @@ func init() {
 						},
 					}, "13", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"11"},
-					&Assign{"FileInfo", nil, "11"},
 					&Assign{"12", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -3970,7 +3959,6 @@ func init() {
 						},
 					}, "14", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"12"},
-					&Assign{"Info", nil, "12"},
 					&Assign{"13", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -4057,7 +4045,6 @@ func init() {
 						},
 					}, "9", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"13"},
-					&Assign{"Open", nil, "13"},
 					&Assign{"14", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -4067,7 +4054,6 @@ func init() {
 						},
 					}, "10", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"14"},
-					&Assign{"Remove", nil, "14"},
 					&Assign{"15", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -4080,7 +4066,6 @@ func init() {
 						},
 					}, "11", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"15"},
-					&Assign{"Rename", nil, "15"},
 					&Assign{"16", &ast.Literal{&types.Type{
 						Kind: 10,
 						Returns: []*types.Type{
@@ -4090,6 +4075,21 @@ func init() {
 						},
 					}, "15", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"16"},
+					&Assign{"1", nil, "1"},
+					&Assign{"10", nil, "2"},
+					&Assign{"11", nil, "3"},
+					&Assign{"12", nil, "4"},
+					&Assign{"13", nil, "5"},
+					&Assign{"14", nil, "6"},
+					&Assign{"15", nil, "7"},
+					&Assign{"9", nil, "8"},
+					&Assign{"CreateDirectory", nil, "9"},
+					&Assign{"File", nil, "10"},
+					&Assign{"FileInfo", nil, "11"},
+					&Assign{"Info", nil, "12"},
+					&Assign{"Open", nil, "13"},
+					&Assign{"Remove", nil, "14"},
+					&Assign{"Rename", nil, "15"},
 					&Assign{"TempPath", nil, "16"},
 					&Return{Registers{"0"}},
 				},
@@ -5418,7 +5418,6 @@ func init() {
 						},
 					}, "1", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"1"},
-					&Assign{"1", nil, "1"},
 					&Assign{"2", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -5436,7 +5435,6 @@ func init() {
 						},
 					}, "2", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"2"},
-					&Assign{"2", nil, "2"},
 					&Assign{"3", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -5451,7 +5449,6 @@ func init() {
 						},
 					}, "3", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"3"},
-					&Assign{"3", nil, "3"},
 					&Assign{"4", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -5466,7 +5463,6 @@ func init() {
 						},
 					}, "4", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"4"},
-					&Assign{"4", nil, "4"},
 					&Assign{"5", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -5481,7 +5477,6 @@ func init() {
 						},
 					}, "5", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"5"},
-					&Assign{"5", nil, "5"},
 					&Assign{"6", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -5499,7 +5494,6 @@ func init() {
 						},
 					}, "6", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"6"},
-					&Assign{"6", nil, "6"},
 					&Assign{"7", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -5520,7 +5514,6 @@ func init() {
 						},
 					}, "7", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"7"},
-					&Assign{"7", nil, "7"},
 					&Assign{"8", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -5538,7 +5531,6 @@ func init() {
 						},
 					}, "8", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"8"},
-					&Assign{"8", nil, "8"},
 					&Assign{"9", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -5553,7 +5545,6 @@ func init() {
 						},
 					}, "9", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"9"},
-					&Assign{"9", nil, "9"},
 					&Assign{"10", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -5577,7 +5568,6 @@ func init() {
 						},
 					}, "1", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"10"},
-					&Assign{"Call", nil, "10"},
 					&Assign{"11", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -5595,7 +5585,6 @@ func init() {
 						},
 					}, "2", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"11"},
-					&Assign{"Get", nil, "11"},
 					&Assign{"12", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -5610,7 +5599,6 @@ func init() {
 						},
 					}, "3", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"12"},
-					&Assign{"Interface", nil, "12"},
 					&Assign{"13", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -5625,7 +5613,6 @@ func init() {
 						},
 					}, "4", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"13"},
-					&Assign{"Kind", nil, "13"},
 					&Assign{"14", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -5640,7 +5627,6 @@ func init() {
 						},
 					}, "5", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"14"},
-					&Assign{"Len", nil, "14"},
 					&Assign{"15", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -5658,7 +5644,6 @@ func init() {
 						},
 					}, "6", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"15"},
-					&Assign{"Properties", nil, "15"},
 					&Assign{"16", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -5679,7 +5664,6 @@ func init() {
 						},
 					}, "7", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"16"},
-					&Assign{"Set", nil, "16"},
 					&Assign{"17", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -5694,7 +5678,6 @@ func init() {
 						},
 					}, "9", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"17"},
-					&Assign{"Type", nil, "17"},
 					&Assign{"18", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -5712,6 +5695,23 @@ func init() {
 						},
 					}, "8", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"18"},
+					&Assign{"1", nil, "1"},
+					&Assign{"2", nil, "2"},
+					&Assign{"3", nil, "3"},
+					&Assign{"4", nil, "4"},
+					&Assign{"5", nil, "5"},
+					&Assign{"6", nil, "6"},
+					&Assign{"7", nil, "7"},
+					&Assign{"8", nil, "8"},
+					&Assign{"9", nil, "9"},
+					&Assign{"Call", nil, "10"},
+					&Assign{"Get", nil, "11"},
+					&Assign{"Interface", nil, "12"},
+					&Assign{"Kind", nil, "13"},
+					&Assign{"Len", nil, "14"},
+					&Assign{"Properties", nil, "15"},
+					&Assign{"Set", nil, "16"},
+					&Assign{"Type", nil, "17"},
 					&Assign{"hasPrefix", nil, "18"},
 					&Return{Registers{"0"}},
 				},
@@ -8213,7 +8213,6 @@ func init() {
 						},
 					}, "1", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"1"},
-					&Assign{"1", nil, "1"},
 					&Assign{"2", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8231,7 +8230,6 @@ func init() {
 						},
 					}, "10", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"2"},
-					&Assign{"10", nil, "2"},
 					&Assign{"3", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8252,7 +8250,6 @@ func init() {
 						},
 					}, "11", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"3"},
-					&Assign{"11", nil, "3"},
 					&Assign{"4", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8273,7 +8270,6 @@ func init() {
 						},
 					}, "12", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"4"},
-					&Assign{"12", nil, "4"},
 					&Assign{"5", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8294,7 +8290,6 @@ func init() {
 						},
 					}, "13", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"5"},
-					&Assign{"13", nil, "5"},
 					&Assign{"6", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8315,7 +8310,6 @@ func init() {
 						},
 					}, "14", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"6"},
-					&Assign{"14", nil, "6"},
 					&Assign{"7", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8333,7 +8327,6 @@ func init() {
 						},
 					}, "15", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"7"},
-					&Assign{"15", nil, "7"},
 					&Assign{"8", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8351,7 +8344,6 @@ func init() {
 						},
 					}, "16", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"8"},
-					&Assign{"16", nil, "8"},
 					&Assign{"9", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8372,7 +8364,6 @@ func init() {
 						},
 					}, "17", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"9"},
-					&Assign{"17", nil, "9"},
 					&Assign{"10", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8387,7 +8378,6 @@ func init() {
 						},
 					}, "18", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"10"},
-					&Assign{"18", nil, "10"},
 					&Assign{"11", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8408,7 +8398,6 @@ func init() {
 						},
 					}, "19", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"11"},
-					&Assign{"19", nil, "11"},
 					&Assign{"12", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8423,7 +8412,6 @@ func init() {
 						},
 					}, "2", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"12"},
-					&Assign{"2", nil, "12"},
 					&Assign{"13", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8444,7 +8432,6 @@ func init() {
 						},
 					}, "20", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"13"},
-					&Assign{"20", nil, "13"},
 					&Assign{"14", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8462,7 +8449,6 @@ func init() {
 						},
 					}, "21", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"14"},
-					&Assign{"21", nil, "14"},
 					&Assign{"15", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8480,7 +8466,6 @@ func init() {
 						},
 					}, "22", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"15"},
-					&Assign{"22", nil, "15"},
 					&Assign{"16", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8498,7 +8483,6 @@ func init() {
 						},
 					}, "23", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"16"},
-					&Assign{"23", nil, "16"},
 					&Assign{"17", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8516,7 +8500,6 @@ func init() {
 						},
 					}, "24", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"17"},
-					&Assign{"24", nil, "17"},
 					&Assign{"18", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8534,7 +8517,6 @@ func init() {
 						},
 					}, "25", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"18"},
-					&Assign{"25", nil, "18"},
 					&Assign{"19", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8552,7 +8534,6 @@ func init() {
 						},
 					}, "26", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"19"},
-					&Assign{"26", nil, "19"},
 					&Assign{"20", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8570,7 +8551,6 @@ func init() {
 						},
 					}, "3", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"20"},
-					&Assign{"3", nil, "20"},
 					&Assign{"21", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8588,7 +8568,6 @@ func init() {
 						},
 					}, "4", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"21"},
-					&Assign{"4", nil, "21"},
 					&Assign{"22", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8606,7 +8585,6 @@ func init() {
 						},
 					}, "5", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"22"},
-					&Assign{"5", nil, "22"},
 					&Assign{"23", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8624,7 +8602,6 @@ func init() {
 						},
 					}, "6", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"23"},
-					&Assign{"6", nil, "23"},
 					&Assign{"24", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8645,7 +8622,6 @@ func init() {
 						},
 					}, "7", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"24"},
-					&Assign{"7", nil, "24"},
 					&Assign{"25", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8663,7 +8639,6 @@ func init() {
 						},
 					}, "8", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"25"},
-					&Assign{"8", nil, "25"},
 					&Assign{"26", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8681,7 +8656,6 @@ func init() {
 						},
 					}, "9", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"26"},
-					&Assign{"9", nil, "26"},
 					&Assign{"27", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8699,7 +8673,6 @@ func init() {
 						},
 					}, "3", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"27"},
-					&Assign{"Contains", nil, "27"},
 					&Assign{"28", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8717,7 +8690,6 @@ func init() {
 						},
 					}, "4", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"28"},
-					&Assign{"HasPrefix", nil, "28"},
 					&Assign{"29", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8735,7 +8707,6 @@ func init() {
 						},
 					}, "5", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"29"},
-					&Assign{"HasSuffix", nil, "29"},
 					&Assign{"30", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8753,7 +8724,6 @@ func init() {
 						},
 					}, "6", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"30"},
-					&Assign{"Index", nil, "30"},
 					&Assign{"31", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8774,7 +8744,6 @@ func init() {
 						},
 					}, "7", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"31"},
-					&Assign{"IndexAfter", nil, "31"},
 					&Assign{"32", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8795,7 +8764,6 @@ func init() {
 						},
 					}, "12", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"32"},
-					&Assign{"Join", nil, "32"},
 					&Assign{"33", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8813,7 +8781,6 @@ func init() {
 						},
 					}, "10", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"33"},
-					&Assign{"LastIndex", nil, "33"},
 					&Assign{"34", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8834,7 +8801,6 @@ func init() {
 						},
 					}, "11", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"34"},
-					&Assign{"LastIndexBefore", nil, "34"},
 					&Assign{"35", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8855,7 +8821,6 @@ func init() {
 						},
 					}, "13", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"35"},
-					&Assign{"PadLeft", nil, "35"},
 					&Assign{"36", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8876,7 +8841,6 @@ func init() {
 						},
 					}, "14", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"36"},
-					&Assign{"PadRight", nil, "36"},
 					&Assign{"37", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8894,7 +8858,6 @@ func init() {
 						},
 					}, "16", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"37"},
-					&Assign{"Repeat", nil, "37"},
 					&Assign{"38", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8915,7 +8878,6 @@ func init() {
 						},
 					}, "17", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"38"},
-					&Assign{"ReplaceAll", nil, "38"},
 					&Assign{"39", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8930,7 +8892,6 @@ func init() {
 						},
 					}, "18", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"39"},
-					&Assign{"Reverse", nil, "39"},
 					&Assign{"40", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8951,7 +8912,6 @@ func init() {
 						},
 					}, "19", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"40"},
-					&Assign{"Split", nil, "40"},
 					&Assign{"41", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8972,7 +8932,6 @@ func init() {
 						},
 					}, "20", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"41"},
-					&Assign{"Substr", nil, "41"},
 					&Assign{"42", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -8987,7 +8946,6 @@ func init() {
 						},
 					}, "1", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"42"},
-					&Assign{"ToLower", nil, "42"},
 					&Assign{"43", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -9002,7 +8960,6 @@ func init() {
 						},
 					}, "2", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"43"},
-					&Assign{"ToUpper", nil, "43"},
 					&Assign{"44", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -9020,7 +8977,6 @@ func init() {
 						},
 					}, "23", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"44"},
-					&Assign{"Trim", nil, "44"},
 					&Assign{"45", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -9038,7 +8994,6 @@ func init() {
 						},
 					}, "21", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"45"},
-					&Assign{"TrimLeft", nil, "45"},
 					&Assign{"46", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -9056,7 +9011,6 @@ func init() {
 						},
 					}, "24", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"46"},
-					&Assign{"TrimPrefix", nil, "46"},
 					&Assign{"47", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -9074,7 +9028,6 @@ func init() {
 						},
 					}, "22", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"47"},
-					&Assign{"TrimRight", nil, "47"},
 					&Assign{"48", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -9092,7 +9045,6 @@ func init() {
 						},
 					}, "25", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"48"},
-					&Assign{"TrimSuffix", nil, "48"},
 					&Assign{"49", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -9110,7 +9062,6 @@ func init() {
 						},
 					}, "15", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"49"},
-					&Assign{"createPad", nil, "49"},
 					&Assign{"50", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -9128,7 +9079,6 @@ func init() {
 						},
 					}, "9", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"50"},
-					&Assign{"max", nil, "50"},
 					&Assign{"51", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -9146,7 +9096,6 @@ func init() {
 						},
 					}, "8", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"51"},
-					&Assign{"min", nil, "51"},
 					&Assign{"52", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -9164,6 +9113,57 @@ func init() {
 						},
 					}, "26", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"52"},
+					&Assign{"1", nil, "1"},
+					&Assign{"10", nil, "2"},
+					&Assign{"11", nil, "3"},
+					&Assign{"12", nil, "4"},
+					&Assign{"13", nil, "5"},
+					&Assign{"14", nil, "6"},
+					&Assign{"15", nil, "7"},
+					&Assign{"16", nil, "8"},
+					&Assign{"17", nil, "9"},
+					&Assign{"18", nil, "10"},
+					&Assign{"19", nil, "11"},
+					&Assign{"2", nil, "12"},
+					&Assign{"20", nil, "13"},
+					&Assign{"21", nil, "14"},
+					&Assign{"22", nil, "15"},
+					&Assign{"23", nil, "16"},
+					&Assign{"24", nil, "17"},
+					&Assign{"25", nil, "18"},
+					&Assign{"26", nil, "19"},
+					&Assign{"3", nil, "20"},
+					&Assign{"4", nil, "21"},
+					&Assign{"5", nil, "22"},
+					&Assign{"6", nil, "23"},
+					&Assign{"7", nil, "24"},
+					&Assign{"8", nil, "25"},
+					&Assign{"9", nil, "26"},
+					&Assign{"Contains", nil, "27"},
+					&Assign{"HasPrefix", nil, "28"},
+					&Assign{"HasSuffix", nil, "29"},
+					&Assign{"Index", nil, "30"},
+					&Assign{"IndexAfter", nil, "31"},
+					&Assign{"Join", nil, "32"},
+					&Assign{"LastIndex", nil, "33"},
+					&Assign{"LastIndexBefore", nil, "34"},
+					&Assign{"PadLeft", nil, "35"},
+					&Assign{"PadRight", nil, "36"},
+					&Assign{"Repeat", nil, "37"},
+					&Assign{"ReplaceAll", nil, "38"},
+					&Assign{"Reverse", nil, "39"},
+					&Assign{"Split", nil, "40"},
+					&Assign{"Substr", nil, "41"},
+					&Assign{"ToLower", nil, "42"},
+					&Assign{"ToUpper", nil, "43"},
+					&Assign{"Trim", nil, "44"},
+					&Assign{"TrimLeft", nil, "45"},
+					&Assign{"TrimPrefix", nil, "46"},
+					&Assign{"TrimRight", nil, "47"},
+					&Assign{"TrimSuffix", nil, "48"},
+					&Assign{"createPad", nil, "49"},
+					&Assign{"max", nil, "50"},
+					&Assign{"min", nil, "51"},
 					&Assign{"substrFrom", nil, "52"},
 					&Return{Registers{"0"}},
 				},
@@ -13567,7 +13567,6 @@ func init() {
 							},
 						}, "13", nil, nil, "", nil, nil}, ""},
 						&ParentScope{"2"},
-						&Assign{"String", nil, "2"},
 						&Assign{"3", &ast.Literal{&types.Type{
 							Kind: 10,
 							Returns: []*types.Type{
@@ -13577,7 +13576,6 @@ func init() {
 							},
 						}, "12", nil, nil, "", nil, nil}, ""},
 						&ParentScope{"3"},
-						&Assign{"Hours", nil, "3"},
 						&Assign{"4", &ast.Literal{&types.Type{
 							Kind: 10,
 							Returns: []*types.Type{
@@ -13587,7 +13585,6 @@ func init() {
 							},
 						}, "11", nil, nil, "", nil, nil}, ""},
 						&ParentScope{"4"},
-						&Assign{"Minutes", nil, "4"},
 						&Assign{"5", &ast.Literal{&types.Type{
 							Kind: 10,
 							Returns: []*types.Type{
@@ -13597,7 +13594,6 @@ func init() {
 							},
 						}, "10", nil, nil, "", nil, nil}, ""},
 						&ParentScope{"5"},
-						&Assign{"Seconds", nil, "5"},
 						&Assign{"6", &ast.Literal{&types.Type{
 							Kind: 10,
 							Returns: []*types.Type{
@@ -13607,7 +13603,6 @@ func init() {
 							},
 						}, "9", nil, nil, "", nil, nil}, ""},
 						&ParentScope{"6"},
-						&Assign{"Milliseconds", nil, "6"},
 						&Assign{"7", &ast.Literal{&types.Type{
 							Kind: 10,
 							Returns: []*types.Type{
@@ -13617,7 +13612,6 @@ func init() {
 							},
 						}, "8", nil, nil, "", nil, nil}, ""},
 						&ParentScope{"7"},
-						&Assign{"Microseconds", nil, "7"},
 						&Assign{"8", &ast.Literal{&types.Type{
 							Kind: 10,
 							Returns: []*types.Type{
@@ -13627,6 +13621,12 @@ func init() {
 							},
 						}, "7", nil, nil, "", nil, nil}, ""},
 						&ParentScope{"8"},
+						&Assign{"String", nil, "2"},
+						&Assign{"Hours", nil, "3"},
+						&Assign{"Minutes", nil, "4"},
+						&Assign{"Seconds", nil, "5"},
+						&Assign{"Milliseconds", nil, "6"},
+						&Assign{"Microseconds", nil, "7"},
 						&Assign{"Nanoseconds", nil, "8"},
 						&Return{Registers{"0"}},
 					},
@@ -13893,78 +13893,6 @@ func init() {
 			},
 			PackageFunc: &CompiledFunc{
 				Instructions: []Instruction{
-					&Assign{"1", &ast.Literal{&types.Type{
-						Kind: 6,
-					}, "4", nil, nil, "lib/time/time.ok:4:9", nil, nil}, ""},
-					&Assign{"April", nil, "1"},
-					&Assign{"2", &ast.Literal{&types.Type{
-						Kind: 6,
-					}, "8", nil, nil, "lib/time/time.ok:8:10", nil, nil}, ""},
-					&Assign{"August", nil, "2"},
-					&Assign{"3", &ast.Literal{&types.Type{
-						Kind: 6,
-					}, "12", nil, nil, "lib/time/time.ok:12:12", nil, nil}, ""},
-					&Assign{"December", nil, "3"},
-					&Assign{"4", &ast.Literal{&types.Type{
-						Kind: 6,
-					}, "2", nil, nil, "lib/time/time.ok:2:12", nil, nil}, ""},
-					&Assign{"February", nil, "4"},
-					&Assign{"5", &ast.Literal{&types.Type{
-						Kind: 6,
-					}, "3600", nil, nil, "lib/time/duration.ok:8:15", nil, nil}, ""},
-					&Assign{"Hour", nil, "5"},
-					&Assign{"6", &ast.Literal{&types.Type{
-						Kind: 6,
-					}, "1", nil, nil, "lib/time/time.ok:1:11", nil, nil}, ""},
-					&Assign{"January", nil, "6"},
-					&Assign{"7", &ast.Literal{&types.Type{
-						Kind: 6,
-					}, "7", nil, nil, "lib/time/time.ok:7:8", nil, nil}, ""},
-					&Assign{"July", nil, "7"},
-					&Assign{"8", &ast.Literal{&types.Type{
-						Kind: 6,
-					}, "6", nil, nil, "lib/time/time.ok:6:8", nil, nil}, ""},
-					&Assign{"June", nil, "8"},
-					&Assign{"9", &ast.Literal{&types.Type{
-						Kind: 6,
-					}, "3", nil, nil, "lib/time/time.ok:3:9", nil, nil}, ""},
-					&Assign{"March", nil, "9"},
-					&Assign{"10", &ast.Literal{&types.Type{
-						Kind: 6,
-					}, "5", nil, nil, "lib/time/time.ok:5:7", nil, nil}, ""},
-					&Assign{"May", nil, "10"},
-					&Assign{"11", &ast.Literal{&types.Type{
-						Kind: 6,
-					}, "0.000001", nil, nil, "lib/time/duration.ok:4:15", nil, nil}, ""},
-					&Assign{"Microsecond", nil, "11"},
-					&Assign{"12", &ast.Literal{&types.Type{
-						Kind: 6,
-					}, "0.001", nil, nil, "lib/time/duration.ok:5:15", nil, nil}, ""},
-					&Assign{"Millisecond", nil, "12"},
-					&Assign{"13", &ast.Literal{&types.Type{
-						Kind: 6,
-					}, "60", nil, nil, "lib/time/duration.ok:7:15", nil, nil}, ""},
-					&Assign{"Minute", nil, "13"},
-					&Assign{"14", &ast.Literal{&types.Type{
-						Kind: 6,
-					}, "0.000000001", nil, nil, "lib/time/duration.ok:3:15", nil, nil}, ""},
-					&Assign{"Nanosecond", nil, "14"},
-					&Assign{"15", &ast.Literal{&types.Type{
-						Kind: 6,
-					}, "11", nil, nil, "lib/time/time.ok:11:12", nil, nil}, ""},
-					&Assign{"November", nil, "15"},
-					&Assign{"16", &ast.Literal{&types.Type{
-						Kind: 6,
-					}, "10", nil, nil, "lib/time/time.ok:10:11", nil, nil}, ""},
-					&Assign{"October", nil, "16"},
-					&Assign{"17", &ast.Literal{&types.Type{
-						Kind: 6,
-					}, "1", nil, nil, "lib/time/duration.ok:6:15", nil, nil}, ""},
-					&Assign{"Second", nil, "17"},
-					&Assign{"18", &ast.Literal{&types.Type{
-						Kind: 6,
-					}, "9", nil, nil, "lib/time/time.ok:9:13", nil, nil}, ""},
-					&Assign{"September", nil, "18"},
 					&Assign{"19", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -14099,7 +14027,6 @@ func init() {
 						},
 					}, "1", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"19"},
-					&Assign{"1", nil, "19"},
 					&Assign{"20", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -14114,7 +14041,6 @@ func init() {
 						},
 					}, "14", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"20"},
-					&Assign{"14", nil, "20"},
 					&Assign{"21", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -14183,7 +14109,6 @@ func init() {
 						},
 					}, "15", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"21"},
-					&Assign{"15", nil, "21"},
 					&Assign{"22", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -14242,7 +14167,6 @@ func init() {
 						},
 					}, "16", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"22"},
-					&Assign{"16", nil, "22"},
 					&Assign{"23", &ast.Literal{&types.Type{
 						Kind: 10,
 						Returns: []*types.Type{
@@ -14281,7 +14205,6 @@ func init() {
 						},
 					}, "18", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"23"},
-					&Assign{"18", nil, "23"},
 					&Assign{"24", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -14325,7 +14248,6 @@ func init() {
 						},
 					}, "19", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"24"},
-					&Assign{"19", nil, "24"},
 					&Assign{"25", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -14460,7 +14382,6 @@ func init() {
 						},
 					}, "2", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"25"},
-					&Assign{"2", nil, "25"},
 					&Assign{"26", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -14504,7 +14425,6 @@ func init() {
 						},
 					}, "20", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"26"},
-					&Assign{"20", nil, "26"},
 					&Assign{"27", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -14519,7 +14439,6 @@ func init() {
 						},
 					}, "21", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"27"},
-					&Assign{"21", nil, "27"},
 					&Assign{"28", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -14595,7 +14514,6 @@ func init() {
 						},
 					}, "3", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"28"},
-					&Assign{"3", nil, "28"},
 					&Assign{"29", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -14671,7 +14589,6 @@ func init() {
 						},
 					}, "4", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"29"},
-					&Assign{"4", nil, "29"},
 					&Assign{"30", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -14747,7 +14664,6 @@ func init() {
 						},
 					}, "5", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"30"},
-					&Assign{"5", nil, "30"},
 					&Assign{"31", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -14821,7 +14737,6 @@ func init() {
 						},
 					}, "6", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"31"},
-					&Assign{"6", nil, "31"},
 					&Assign{"32", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -14956,7 +14871,6 @@ func init() {
 						},
 					}, "1", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"32"},
-					&Assign{"Add", nil, "32"},
 					&Assign{"33", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -15032,7 +14946,6 @@ func init() {
 						},
 					}, "5", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"33"},
-					&Assign{"After", nil, "33"},
 					&Assign{"34", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -15108,7 +15021,6 @@ func init() {
 						},
 					}, "4", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"34"},
-					&Assign{"Before", nil, "34"},
 					&Assign{"35", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -15182,7 +15094,6 @@ func init() {
 						},
 					}, "6", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"35"},
-					&Assign{"Duration", nil, "35"},
 					&Assign{"36", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -15258,7 +15169,6 @@ func init() {
 						},
 					}, "3", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"36"},
-					&Assign{"Equal", nil, "36"},
 					&Assign{"37", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -15302,7 +15212,6 @@ func init() {
 						},
 					}, "20", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"37"},
-					&Assign{"FromUnix", nil, "37"},
 					&Assign{"38", &ast.Literal{&types.Type{
 						Kind: 10,
 						Returns: []*types.Type{
@@ -15341,7 +15250,6 @@ func init() {
 						},
 					}, "18", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"38"},
-					&Assign{"Now", nil, "38"},
 					&Assign{"39", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -15410,7 +15318,6 @@ func init() {
 						},
 					}, "15", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"39"},
-					&Assign{"Sleep", nil, "39"},
 					&Assign{"40", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -15545,7 +15452,6 @@ func init() {
 						},
 					}, "2", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"40"},
-					&Assign{"Sub", nil, "40"},
 					&Assign{"41", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -15604,7 +15510,6 @@ func init() {
 						},
 					}, "16", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"41"},
-					&Assign{"Time", nil, "41"},
 					&Assign{"42", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -15648,7 +15553,6 @@ func init() {
 						},
 					}, "19", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"42"},
-					&Assign{"Unix", nil, "42"},
 					&Assign{"43", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -15663,7 +15567,6 @@ func init() {
 						},
 					}, "14", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"43"},
-					&Assign{"floor", nil, "43"},
 					&Assign{"44", &ast.Literal{&types.Type{
 						Kind: 10,
 						Arguments: []*types.Type{
@@ -15678,6 +15581,103 @@ func init() {
 						},
 					}, "21", nil, nil, "", nil, nil}, ""},
 					&ParentScope{"44"},
+					&Assign{"1", &ast.Literal{&types.Type{
+						Kind: 6,
+					}, "4", nil, nil, "lib/time/time.ok:4:9", nil, nil}, ""},
+					&Assign{"April", nil, "1"},
+					&Assign{"2", &ast.Literal{&types.Type{
+						Kind: 6,
+					}, "8", nil, nil, "lib/time/time.ok:8:10", nil, nil}, ""},
+					&Assign{"August", nil, "2"},
+					&Assign{"3", &ast.Literal{&types.Type{
+						Kind: 6,
+					}, "12", nil, nil, "lib/time/time.ok:12:12", nil, nil}, ""},
+					&Assign{"December", nil, "3"},
+					&Assign{"4", &ast.Literal{&types.Type{
+						Kind: 6,
+					}, "2", nil, nil, "lib/time/time.ok:2:12", nil, nil}, ""},
+					&Assign{"February", nil, "4"},
+					&Assign{"5", &ast.Literal{&types.Type{
+						Kind: 6,
+					}, "3600", nil, nil, "lib/time/duration.ok:8:15", nil, nil}, ""},
+					&Assign{"Hour", nil, "5"},
+					&Assign{"6", &ast.Literal{&types.Type{
+						Kind: 6,
+					}, "1", nil, nil, "lib/time/time.ok:1:11", nil, nil}, ""},
+					&Assign{"January", nil, "6"},
+					&Assign{"7", &ast.Literal{&types.Type{
+						Kind: 6,
+					}, "7", nil, nil, "lib/time/time.ok:7:8", nil, nil}, ""},
+					&Assign{"July", nil, "7"},
+					&Assign{"8", &ast.Literal{&types.Type{
+						Kind: 6,
+					}, "6", nil, nil, "lib/time/time.ok:6:8", nil, nil}, ""},
+					&Assign{"June", nil, "8"},
+					&Assign{"9", &ast.Literal{&types.Type{
+						Kind: 6,
+					}, "3", nil, nil, "lib/time/time.ok:3:9", nil, nil}, ""},
+					&Assign{"March", nil, "9"},
+					&Assign{"10", &ast.Literal{&types.Type{
+						Kind: 6,
+					}, "5", nil, nil, "lib/time/time.ok:5:7", nil, nil}, ""},
+					&Assign{"May", nil, "10"},
+					&Assign{"11", &ast.Literal{&types.Type{
+						Kind: 6,
+					}, "0.000001", nil, nil, "lib/time/duration.ok:4:15", nil, nil}, ""},
+					&Assign{"Microsecond", nil, "11"},
+					&Assign{"12", &ast.Literal{&types.Type{
+						Kind: 6,
+					}, "0.001", nil, nil, "lib/time/duration.ok:5:15", nil, nil}, ""},
+					&Assign{"Millisecond", nil, "12"},
+					&Assign{"13", &ast.Literal{&types.Type{
+						Kind: 6,
+					}, "60", nil, nil, "lib/time/duration.ok:7:15", nil, nil}, ""},
+					&Assign{"Minute", nil, "13"},
+					&Assign{"14", &ast.Literal{&types.Type{
+						Kind: 6,
+					}, "0.000000001", nil, nil, "lib/time/duration.ok:3:15", nil, nil}, ""},
+					&Assign{"Nanosecond", nil, "14"},
+					&Assign{"15", &ast.Literal{&types.Type{
+						Kind: 6,
+					}, "11", nil, nil, "lib/time/time.ok:11:12", nil, nil}, ""},
+					&Assign{"November", nil, "15"},
+					&Assign{"16", &ast.Literal{&types.Type{
+						Kind: 6,
+					}, "10", nil, nil, "lib/time/time.ok:10:11", nil, nil}, ""},
+					&Assign{"October", nil, "16"},
+					&Assign{"17", &ast.Literal{&types.Type{
+						Kind: 6,
+					}, "1", nil, nil, "lib/time/duration.ok:6:15", nil, nil}, ""},
+					&Assign{"Second", nil, "17"},
+					&Assign{"18", &ast.Literal{&types.Type{
+						Kind: 6,
+					}, "9", nil, nil, "lib/time/time.ok:9:13", nil, nil}, ""},
+					&Assign{"September", nil, "18"},
+					&Assign{"1", nil, "19"},
+					&Assign{"14", nil, "20"},
+					&Assign{"15", nil, "21"},
+					&Assign{"16", nil, "22"},
+					&Assign{"18", nil, "23"},
+					&Assign{"19", nil, "24"},
+					&Assign{"2", nil, "25"},
+					&Assign{"20", nil, "26"},
+					&Assign{"21", nil, "27"},
+					&Assign{"3", nil, "28"},
+					&Assign{"4", nil, "29"},
+					&Assign{"5", nil, "30"},
+					&Assign{"6", nil, "31"},
+					&Assign{"Add", nil, "32"},
+					&Assign{"After", nil, "33"},
+					&Assign{"Before", nil, "34"},
+					&Assign{"Duration", nil, "35"},
+					&Assign{"Equal", nil, "36"},
+					&Assign{"FromUnix", nil, "37"},
+					&Assign{"Now", nil, "38"},
+					&Assign{"Sleep", nil, "39"},
+					&Assign{"Sub", nil, "40"},
+					&Assign{"Time", nil, "41"},
+					&Assign{"Unix", nil, "42"},
+					&Assign{"floor", nil, "43"},
 					&Assign{"zeroPad", nil, "44"},
 					&Return{Registers{"0"}},
 				},


### PR DESCRIPTION
Previously, parent scope variables (eg. ^foo) were not checked in any
way and just hardcoded to be of type number. This was a hack to get the
fundamental mechanics working without all the complexity of adding the
proper implementation to the compiler. Not surprisingly I have now hit
this limit so it has been implemented correctly.

On a side note, there were a bunch of tests commented out that have been
enabled again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/ok/94)
<!-- Reviewable:end -->
