### PR TITLE
ci: Update to go 1.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: go
 
-go: '1.14'
+# macOS traditionally has less backlog on Travis.
+os: osx
+
+go: '1.15'
 
 install:
   - wget https://raw.githubusercontent.com/ekalinin/github-markdown-toc/master/gh-md-toc
@@ -26,4 +29,3 @@ jobs:
         on:
           repo: elliotchance/ok
           all_branches: true
-        skip_cleanup: 'true'


### PR DESCRIPTION
Also the "skip_cleanup" option in the deploy is now deprecated because
it is the default behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/ok/95)
<!-- Reviewable:end -->
