### PR TITLE
Fix panic with any comparison

### DIFF
--- a/lib/lang/compare-any.okt
+++ b/lib/lang/compare-any.okt
@@ -1,0 +1,21 @@
+func compareValue(x any) string {
+    if x == true {
+        return "bool(true)"
+    }
+
+    if 123 == x {
+        return "number(123)"
+    }
+
+    return "unknown"
+}
+
+test "any comparison" {
+    assert(compareValue(true) == "bool(true)")
+    assert(compareValue(false) == "unknown")
+    assert(compareValue(123) == "number(123)")
+    assert(compareValue(123.00) == "number(123)")
+    assert(compareValue(123.01) == "unknown")
+    assert(compareValue("hi") == "unknown")
+    assert(compareValue([]string []) == "unknown")
+}

--- a/vm/equal.go
+++ b/vm/equal.go
@@ -57,6 +57,14 @@ func (ins *Equal) String() string {
 }
 
 func compareValue(a, b *ast.Literal) bool {
+	// This is also used when comparing any values so we have to test for type
+	// here to be sure. Ideally, all of the types will have custom equality -
+	// like EqualNumber - or, at least notify if an any is being used to avoid
+	// this runtime check.
+	if a.Kind.Kind != b.Kind.Kind {
+		return false
+	}
+
 	switch a.Kind.Kind {
 	case types.KindArray:
 		if len(a.Array) == len(b.Array) {


### PR DESCRIPTION
"any" used in an equality comparison (== or !=) was not also checking
that types were the same leading to a panic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/ok/103)
<!-- Reviewable:end -->
