### PR TITLE
Fix "ok test"

### DIFF
--- a/compiler/compile.go
+++ b/compiler/compile.go
@@ -159,6 +159,16 @@ func Compile(
 		file = vm.Merge(append(append([]*vm.File(nil), file), dependencies...)...)
 	}
 
+	// Compile and append tests, if any. Only in the root level package.
+	for _, test := range p.Tests() {
+		compiledTest, err := CompileTest(test, file, p.Constants, imports)
+		if err != nil {
+			return nil, nil, []error{err}
+		}
+
+		file.Tests = append(file.Tests, compiledTest)
+	}
+
 	err = vm.Store(file, packageName)
 	if err != nil {
 		return nil, nil, []error{err}


### PR DESCRIPTION
During the last huge refactoring the code that compiled tests (and hence
included them in the output) was not carried over. This was not caught
because all the packages passed with 0 tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/ok/122)
<!-- Reviewable:end -->
