### PR TITLE
Fixes stack traces and unhandled errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,9 @@ test-coverage:
 run-tests: tests/* run-lib-tests
 
 tests/*: ok
-	./ok run $@ > /tmp/stdout.txt
+	@# Non successful runs will have their exit code appended to the expected
+	@# output so it can be included in the diff.
+	./ok run $@ > /tmp/stdout.txt || (echo "Exit: $$?" >> /tmp/stdout.txt)
 
 	@if [ -f "$@/stdout-ignored.txt" ]; then \
 		echo "Stdout ignored."; \

--- a/compiler/call.go
+++ b/compiler/call.go
@@ -118,6 +118,7 @@ func compileCall(
 		Arguments:    argResults,
 		Results:      returnRegisters,
 		Type:         typeRegister,
+		Pos:          call.Pos,
 	}
 
 	compiledFunc.Append(ins)
@@ -218,6 +219,7 @@ func funcCall(compiledFunc *vm.CompiledFunc, args []vm.Register) (vm.Instruction
 		Variable:  args[0],
 		Arguments: args[1],
 		Results:   result,
+		Pos:       compiledFunc.Pos,
 	}
 
 	return ins, []vm.Register{result}, []*types.Type{types.AnyArray}, nil

--- a/compiler/raise.go
+++ b/compiler/raise.go
@@ -26,6 +26,7 @@ func compileRaise(
 	compiledFunc.Append(&vm.Raise{
 		Err:  result[0],
 		Type: typeRegister,
+		Pos:  n.Pos,
 	})
 
 	return nil

--- a/lib/runtime/stack.okt
+++ b/lib/runtime/stack.okt
@@ -11,7 +11,12 @@ func Bar() StackTrace {
 test "StackTrace.String" {
     stack = foo()
     s = stack.String()
-    assert(strings.Contains(s, "1 Bar ") == true)
+
+    assert(strings.Contains(s, "3 Bar ") == true)
     assert(strings.Contains(s, "2 foo ") == true)
-    assert(strings.Contains(s, "3 test \"StackTrace.String\" ") == true)
+    assert(strings.Contains(s, "1 test \"StackTrace.String\" ") == true)
+
+    assert(strings.Contains(s, "lib/runtime/stack.okt:12") == true)
+    assert(strings.Contains(s, "lib/runtime/stack.okt:4") == true)
+    assert(strings.Contains(s, "lib/runtime/stack.okt:8") == true)
 }

--- a/tests/error-unhandled/main.ok
+++ b/tests/error-unhandled/main.ok
@@ -1,0 +1,13 @@
+import "error"
+
+func foo() {
+    raise error.Error("uh oh")
+}
+
+func bar() {
+    foo()
+}
+
+func main() {
+    bar()
+}

--- a/tests/error-unhandled/stdout.txt
+++ b/tests/error-unhandled/stdout.txt
@@ -1,0 +1,5 @@
+Error: "uh oh"
+  3 foo() at /tests/error-unhandled/main.ok:4:5
+  2 bar() at /tests/error-unhandled/main.ok:8:8
+  1 main() at /tests/error-unhandled/main.ok:12:8
+Exit: 1

--- a/vm/call.go
+++ b/vm/call.go
@@ -15,6 +15,9 @@ type Call struct {
 	// Type is the resolved interface when calling constructors. In any other
 	// case this should be types.Any.
 	Type TypeRegister
+
+	// Pos is used to append to the call stack.
+	Pos string
 }
 
 // Execute implements the Instruction interface for the VM.
@@ -29,7 +32,7 @@ func (ins *Call) Execute(_ *int, vm *VM) error {
 	}
 
 	ty := vm.Types[ins.Type]
-	results, err := vm.call(funcName, ins.Arguments, parentScope, ty)
+	results, err := vm.call(funcName, ins.Arguments, parentScope, ty, ins.Pos)
 	if err != nil {
 		return err
 	}

--- a/vm/dynamic_call.go
+++ b/vm/dynamic_call.go
@@ -12,6 +12,9 @@ type DynamicCall struct {
 	Variable  Register // func literal
 	Arguments Register // []any for arguments
 	Results   Register // []any for return values
+
+	// Pos is used to append to the call stack.
+	Pos string
 }
 
 // Execute implements the Instruction interface for the VM.
@@ -43,6 +46,7 @@ func (ins *DynamicCall) Execute(_ *int, vm *VM) error {
 		FunctionName: "*" + string(ins.Variable),
 		Arguments:    args,
 		Results:      results,
+		Pos:          ins.Pos,
 
 		// TODO(elliot): This should be the correct return type, otherwise the
 		//  reflect won't work.

--- a/vm/raise.go
+++ b/vm/raise.go
@@ -11,12 +11,17 @@ type Raise struct {
 
 	// Type is used to match the handler.
 	Type TypeRegister
+
+	// Pos is used at the top of the stack trace to show where the error
+	// originated from.
+	Pos string
 }
 
 // Execute implements the Instruction interface for the VM.
 func (ins *Raise) Execute(_ *int, vm *VM) error {
 	vm.ErrType = vm.Types[ins.Type]
 	vm.ErrValue = vm.Get(ins.Err)
+	vm.ErrStack = vm.captureCallStack(ins.Pos)
 
 	return nil
 }

--- a/vm/stack.go
+++ b/vm/stack.go
@@ -21,15 +21,10 @@ func reverse(ss []string) {
 
 // Execute implements the Instruction interface for the VM.
 func (ins *Stack) Execute(_ *int, vm *VM) error {
-	var elements []string
+	elements := vm.captureCallStack("")
 
-	// We must exclude the last stack item because that's the code that called
-	// the internal __stack.
-	for _, stack := range vm.Stack[:len(vm.Stack)-1] {
-		elements = append(elements, stack[StackRegister].Value)
-	}
-
-	reverse(elements)
+	// Exclude some elements to avoid including the internal __stack call.
+	elements = elements[2 : len(elements)-1]
 
 	vm.Set(ins.Stack, asttest.NewLiteralString(strings.Join(elements, "\n")))
 


### PR DESCRIPTION
An unhandled error previously resulted in a very unhelpful panic. Now it
prints out the the stack trace.

The stack trace itself also has been fixed to use the positions of the
Call operations (and not the surrounding functions).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/ok/124)
<!-- Reviewable:end -->
