### PR TITLE
Fix jump instructions with closures

### DIFF
--- a/compiler/func.go
+++ b/compiler/func.go
@@ -82,6 +82,24 @@ func CompileFunc(
 		compiled.Instructions.Instructions[instructions:],
 		compiled.Instructions.Instructions[:instructions]...)
 
+	// Since we moved instructions to the top we also need to adjust the jump
+	// positions down accordingly.
+	if instructions > 0 {
+		count := len(compiled.Instructions.Instructions) - instructions
+
+		for index, ins := range compiled.Instructions.Instructions {
+			switch actual := ins.(type) {
+			case *vm.Jump:
+				actual.To += count
+
+			case *vm.JumpUnless:
+				actual.To += count
+			}
+
+			compiled.Instructions.Instructions[index] = ins
+		}
+	}
+
 	return compiled, nil
 }
 

--- a/lexer/tokenize.go
+++ b/lexer/tokenize.go
@@ -424,6 +424,10 @@ func tokenKindForQuote(quote rune) (kind string) {
 }
 
 func appendToken(tokens []Token, token Token, endOfLine *int, pos *Pos) []Token {
+	if token.Kind == TokenEOF {
+		return tokens
+	}
+
 	if *endOfLine > 0 {
 		pos.LineNumber += *endOfLine
 		pos.CharacterNumber = 0

--- a/lexer/tokenize_test.go
+++ b/lexer/tokenize_test.go
@@ -1290,6 +1290,65 @@ func TestTokenizeString(t *testing.T) {
 				{lexer.TokenEOF, "", false, pos(3)},
 			},
 		},
+		"nested-func-and-if": {
+			str: `func foo() {
+				if true == false {
+					print("a")
+				} else {
+					print("b")
+				}
+
+				func bar() {
+					print("c")
+				}
+			}`,
+			expected: []lexer.Token{
+				{lexer.TokenFunc, "func", false, pos(1)},
+				{lexer.TokenIdentifier, "foo", false, pos(6)},
+				{lexer.TokenParenOpen, "(", false, pos(9)},
+				{lexer.TokenParenClose, ")", false, pos(10)},
+				{lexer.TokenCurlyOpen, "{", true, pos(12)},
+
+				{lexer.TokenIf, "if", false, pos2(2, 5)},
+				{lexer.TokenBoolLiteral, "true", false, pos2(2, 8)},
+				{lexer.TokenEqual, "==", false, pos2(2, 13)},
+				{lexer.TokenBoolLiteral, "false", false, pos2(2, 16)},
+				{lexer.TokenCurlyOpen, "{", true, pos2(2, 22)},
+
+				{lexer.TokenIdentifier, "print", false, pos2(3, 6)},
+				{lexer.TokenParenOpen, "(", false, pos2(3, 11)},
+				{lexer.TokenStringLiteral, "a", false, pos2(3, 12)},
+				{lexer.TokenParenClose, ")", true, pos2(3, 15)},
+
+				{lexer.TokenCurlyClose, "}", false, pos2(4, 5)},
+				{lexer.TokenElse, "else", false, pos2(4, 7)},
+				{lexer.TokenCurlyOpen, "{", true, pos2(4, 12)},
+
+				{lexer.TokenIdentifier, "print", false, pos2(5, 6)},
+				{lexer.TokenParenOpen, "(", false, pos2(5, 11)},
+				{lexer.TokenStringLiteral, "b", false, pos2(5, 12)},
+				{lexer.TokenParenClose, ")", true, pos2(5, 15)},
+
+				{lexer.TokenCurlyClose, "}", true, pos2(6, 5)},
+
+				{lexer.TokenFunc, "func", false, pos2(8, 5)},
+				{lexer.TokenIdentifier, "bar", false, pos2(8, 10)},
+				{lexer.TokenParenOpen, "(", false, pos2(8, 13)},
+				{lexer.TokenParenClose, ")", false, pos2(8, 14)},
+				{lexer.TokenCurlyOpen, "{", true, pos2(8, 16)},
+
+				{lexer.TokenIdentifier, "print", false, pos2(9, 6)},
+				{lexer.TokenParenOpen, "(", false, pos2(9, 11)},
+				{lexer.TokenStringLiteral, "c", false, pos2(9, 12)},
+				{lexer.TokenParenClose, ")", true, pos2(9, 15)},
+
+				{lexer.TokenCurlyClose, "}", true, pos2(10, 5)},
+
+				{lexer.TokenCurlyClose, "}", false, pos2(11, 4)},
+
+				{lexer.TokenEOF, "", false, pos2(11, 5)},
+			},
+		},
 	} {
 		t.Run(testName, func(t *testing.T) {
 			options := lexer.Options{

--- a/parser/func_test.go
+++ b/parser/func_test.go
@@ -211,12 +211,74 @@ func TestFunc(t *testing.T) {
 				},
 			},
 		},
+		"if-before-closure": {
+			str: `func foo() {
+				if true == false {
+					print("a")
+				} else {
+					print("b")
+				}
+
+				func bar() {
+					print("c")
+				}
+			}`,
+			expected: map[string]*ast.Func{
+				"1": {
+					Name: "foo",
+					Statements: []ast.Node{
+						&ast.Assign{
+							Lefts: []ast.Node{
+								&ast.Identifier{Name: "bar"},
+							},
+							Rights: []ast.Node{
+								&ast.Func{
+									Name:       "bar",
+									UniqueName: "2",
+									Statements: []ast.Node{
+										&ast.Call{
+											Expr: &ast.Identifier{Name: "print"},
+											Arguments: []ast.Node{
+												asttest.NewLiteralString("c"),
+											},
+										},
+									},
+								},
+							},
+						},
+						&ast.If{
+							Condition: &ast.Binary{
+								Op:    "==",
+								Left:  asttest.NewLiteralBool(true),
+								Right: asttest.NewLiteralBool(false),
+							},
+							True: []ast.Node{
+								&ast.Call{
+									Expr: &ast.Identifier{Name: "print"},
+									Arguments: []ast.Node{
+										asttest.NewLiteralString("a"),
+									},
+								},
+							},
+							False: []ast.Node{
+								&ast.Call{
+									Expr: &ast.Identifier{Name: "print"},
+									Arguments: []ast.Node{
+										asttest.NewLiteralString("b"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(testName, func(t *testing.T) {
 			p := parser.NewParser(0)
 			p.ParseString(test.str, "a.ok")
 
-			assert.Nil(t, p.Errors())
+			assert.Nil(t, p.Errors(), p.Errors())
 			asttest.AssertEqual(t, test.expected, p.Funcs())
 			assert.Nil(t, p.Comments())
 		})


### PR DESCRIPTION
Instructions for assigning closures to variables are hoisted to the top
of the scope which means all the instructions need to have their jump
positions corrected below.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/ok/126)
<!-- Reviewable:end -->
