### PR TITLE
Types cannot span more than one line

### DIFF
--- a/parser/func.go
+++ b/parser/func.go
@@ -49,7 +49,12 @@ func consumeFunc(parser *Parser, offset int) (_ *ast.Func, _ int, anon bool, fin
 		return nil, originalOffset, anon, err
 	}
 
-	if parser.tokens[offset].Kind != lexer.TokenCurlyOpen {
+	// The next "{" will be ambiguous because it could be a map or the start of
+	// the block. Try to consume types first, and fallback to treating it as the
+	// start of the block.
+	fn.Returns, offset, err = consumeTypes(parser, offset, false)
+
+	if parser.tokens[offset].Kind != lexer.TokenCurlyOpen && err != nil {
 		fn.Returns, offset, err = consumeTypes(parser, offset, false)
 		if err != nil {
 			return nil, originalOffset, anon, err

--- a/parser/func_test.go
+++ b/parser/func_test.go
@@ -273,6 +273,17 @@ func TestFunc(t *testing.T) {
 				},
 			},
 		},
+		"return-any-map": {
+			str: "func foo() {}any { }",
+			expected: map[string]*ast.Func{
+				"1": {
+					Name: "foo",
+					Returns: []*types.Type{
+						types.AnyMap,
+					},
+				},
+			},
+		},
 	} {
 		t.Run(testName, func(t *testing.T) {
 			p := parser.NewParser(0)

--- a/parser/type.go
+++ b/parser/type.go
@@ -27,9 +27,16 @@ func consumeType(parser *Parser, offset int) (ty *types.Type, _ int, _ error) {
 	}()
 
 	for {
+		// The IsEndOfLine checks here are important because a type cannot span
+		// more than one line. This is how we differentiate between a type and
+		// what might look like the next function;
+		//
+		//   func foo() {} func bar() {}
+
 		switch {
 		case parser.tokens[offset].Kind == lexer.TokenSquareOpen &&
-			parser.tokens[offset+1].Kind == lexer.TokenSquareClose:
+			parser.tokens[offset+1].Kind == lexer.TokenSquareClose &&
+			!parser.tokens[offset+1].IsEndOfLine:
 			offset += 2
 			defers = append(defers, func() {
 				if ty != nil {
@@ -38,7 +45,8 @@ func consumeType(parser *Parser, offset int) (ty *types.Type, _ int, _ error) {
 			})
 
 		case parser.tokens[offset].Kind == lexer.TokenCurlyOpen &&
-			parser.tokens[offset+1].Kind == lexer.TokenCurlyClose:
+			parser.tokens[offset+1].Kind == lexer.TokenCurlyClose &&
+			!parser.tokens[offset+1].IsEndOfLine:
 			offset += 2
 			defers = append(defers, func() {
 				if ty != nil {


### PR DESCRIPTION
The IsEndOfLine checks on consuming types are important because a type
cannot span more than one line. This is how we differentiate between a
type and what might look like the next function:

    func foo() {} func bar() {}

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/ok/127)
<!-- Reviewable:end -->
